### PR TITLE
[ONGOING] Update PREDICT syntax

### DIFF
--- a/dbengine/src/backend/commands/predict.c
+++ b/dbengine/src/backend/commands/predict.c
@@ -124,7 +124,7 @@ ExecPredictStmt(NeurDBPredictStmt *stmt, ParseState *pstate, const char *whereCl
     ListCell *o_target;
     StringInfoData columns;
     char *tableName = NULL;
-    char *whereClause = NULL;
+    char *whereClause = "<DEPRECATED>";
 
     elog(DEBUG1, "Starting ExecPredictStmt");
     initStringInfo(&columns);
@@ -169,13 +169,13 @@ ExecPredictStmt(NeurDBPredictStmt *stmt, ParseState *pstate, const char *whereCl
     }
 
     /* Convert whereClause to string */
-    if (stmt->whereClause != NULL) {
-        whereClause = nodeToString(stmt->whereClause);
-        elog(DEBUG1, "Extracted where clause: %s", whereClause);
-    } else {
-        elog(DEBUG1, "No where clause provided");
-        whereClause = "";
-    }
+    // if (stmt->whereClause != NULL) {
+    //     whereClause = nodeToString(stmt->whereClause);
+    //     elog(DEBUG1, "Extracted where clause: %s", whereClause);
+    // } else {
+    //     elog(DEBUG1, "No where clause provided");
+    //     whereClause = "";
+    // }
 
     /* Execute the UDF with extracted columns, table name, and where clause */
     elog(DEBUG1, "Executing UDF with columns: %s, table: %s, whereClause: %s", columns.data, tableName, whereClause);

--- a/dbengine/src/backend/nodes/gen_node_support.pl
+++ b/dbengine/src/backend/nodes/gen_node_support.pl
@@ -107,7 +107,7 @@ my @nodetag_only_files = qw(
 # ABI stability during development.
 
 my $last_nodetag = 'WindowObjectData';
-my $last_nodetag_no = 455;
+my $last_nodetag_no = 456;
 
 # output file names
 my @output_files;

--- a/dbengine/src/backend/storage/lmgr/policy.c
+++ b/dbengine/src/backend/storage/lmgr/policy.c
@@ -18,12 +18,12 @@ const uint32_t timeout_choices[10] = {1, 4, 8, 16, 64, 128, 256, 512, 1024, 0};
 // OP, STEP, DEP, REQ, GRANTED
 const uint32_t feature_bits[] = {1, 3, 2, 2, 2};
 
-inline uint32_t minUInt32(uint32_t x, uint32_t y) {
+uint32_t minUInt32(uint32_t x, uint32_t y) {
 if (x < y) return x;
 return y;
 }
 
-inline uint32_t encode_tx_state() {
+uint32_t encode_tx_state() {
     uint32_t res = 0, i = 0;
     Assert(RLState->op >= 0 && RLState->op <= 1);
     Assert(RLState->n_r >= 0);

--- a/dbengine/src/include/nodes/parsenodes.h
+++ b/dbengine/src/include/nodes/parsenodes.h
@@ -4052,22 +4052,37 @@ typedef struct DropSubscriptionStmt
  * NEURDB
 */
 
-typedef enum PredictType
+typedef struct NeurDBTrainOnSpec
 {
-	PREDICT_CLASS,				/* Classification prediction. */
-	PREDICT_VALUE				/* Value prediction. */
-}			PredictType;
+  NodeTag 		type;      /* Node type identifier */
+  
+  List 			*trainOn;     /* Columns used to train the model */
+  Node 			*trainOnWith; /* Filtering data. Same as WHERE clause before (and that in
+                        SELECT) */
+} NeurDBTrainOnSpec;
 
-typedef struct NeurDBPredictStmt
+typedef enum PredictType 
 {
-	NodeTag		type;			/* Node type identifier */
-	PredictType kind;			/* Task type (classification or value
-								 * prediction) */
-	List	   *targetList;		/* A list of targets (columns) for the
-								 * prediction */
-	List	   *fromClause;		/* A list of tables involved in the prediction */
-	Node	   *whereClause;	/* The WHERE clause for filtering data */
-	bool		allowTrain;	/* Let DB train a model if it does not exist? */
-}			NeurDBPredictStmt;
+  PREDICT_CLASS, /* Classification prediction. */
+  PREDICT_VALUE  /* Value prediction. */
+} PredictType;
+
+typedef struct NeurDBPredictStmt 
+{
+  	NodeTag 	type;      /* Node type identifier */
+
+  	PredictType kind;  /* Task type (classification or value
+                      * prediction) */
+  	List 		*targetList;  /* A list of targets (columns) for the
+                      * prediction */
+  	List 		*fromClause;  /* A list of tables involved in the prediction */
+  	Node 		*trainOnSpec;     /* Sepc for the TRAIN ON syntax */
+  	SelectStmt 	*values;    /* Values (following definition of 'values_clause' symbol) */
+} NeurDBPredictStmt;
 
 #endif							/* PARSENODES_H */
+
+#if 0
+Node *whereClause; /* The WHERE clause for filtering data */
+bool allowTrain;   /* Let DB train a model if it does not exist? */
+#endif


### PR DESCRIPTION
Enhancing the TRAIN ON clause of the PREDICT syntax.

## TODO
- [x] Modify parser and NeurDBPredictStmt node to include necessary information
- [ ] Handle logic in `predict.c`