### PR TITLE
[Partial] Runtime parameters

### DIFF
--- a/dbengine/src/backend/commands/predict.c
+++ b/dbengine/src/backend/commands/predict.c
@@ -21,16 +21,53 @@
 #include "utils/array.h"
 #include "nodes/primnodes.h"
 
+/**
+ * Static (fixed) look-up variables
+ */
+char	   *modelLookupFuncName = "nr_model_lookup";
+#define MODEL_LOOKUP_PARAMS_ARRAY_SIZE 3
+Oid			modelLookupArgTypes[MODEL_LOOKUP_PARAMS_ARRAY_SIZE] = {TEXTOID, TEXTARRAYOID, TEXTOID};
+
+#define TRAINING_PARAMS_ARRAY_SIZE 8
+char	   *trainingFuncName = "nr_train";
+Oid			trainingArgTypes[TRAINING_PARAMS_ARRAY_SIZE] = {TEXTOID, TEXTOID, INT4OID, INT4OID, INT4OID, INT4OID, TEXTARRAYOID, TEXTOID};
+
+#define INFERENCE_PARAMS_ARRAY_SIZE 7
+char	   *inferenceFuncName = "nr_inference";
+Oid			inferenceArgTypes[INFERENCE_PARAMS_ARRAY_SIZE] = {TEXTOID, INT4OID, TEXTOID, INT4OID, INT4OID, INT4OID, TEXTARRAYOID};
+
+/**
+ * Configurable parameters
+ *
+ * Set in `backend/utils/misc/guc_tables.c`
+ */
+char	   *NRModelName = NULL;
+int			NRTaskBatchSize;
+int			NRTaskEpoch;
+int			NRTaskMaxFeatures;
+int			NRTaskNumBatches;
 
 static List *
-split_columns(const char *columns) {
-    List *result = NIL;
-    char *token = strtok(columns, ",");
-    while (token != NULL) {
-        result = lappend(result, makeString(token));
-        token = strtok(NULL, ",");
-    }
-    return result;
+split_columns(const char *columns)
+{
+	List	   *result = NIL;
+	char	   *token = strtok(columns, ",");
+
+	while (token != NULL)
+	{
+		result = lappend(result, makeString(token));
+		token = strtok(NULL, ",");
+	}
+	return result;
+}
+
+static void 
+set_false_to_all_params(NullableDatum *args, int size)
+{
+	for (int i = 0; i < size; i++)
+	{
+		args[i].isnull = false;
+	}
 }
 
 /*
@@ -45,147 +82,139 @@ split_columns(const char *columns) {
 * needs to be revamped to be more general.
 */
 void
-exec_udf(const char *table, const char *trainColumns, const char *targetColumn, const char *whereClause) {
-    // lookup function call infos
-    FmgrInfo modelLookupFmgrInfo;
-    LOCAL_FCINFO(modelLookupFCInfo, FUNC_MAX_ARGS); // fcinfo for lookup function
-    Datum modelLookupResult;
-    Oid modelLookupArgTypes[3] = {TEXTOID, TEXTARRAYOID, TEXTOID};
-    char modelLookupFuncName[] = "nr_model_lookup";
+exec_udf(const char *table, const char *trainColumns, const char *targetColumn, const char *whereClause)
+{
+	/* lookup function call infos */
+	FmgrInfo	modelLookupFmgrInfo;
+	/* fcinfo for lookup function */
+	LOCAL_FCINFO(modelLookupFCInfo, FUNC_MAX_ARGS);
+	Datum		modelLookupResult;
 
-    Oid modelLookupFuncOid = LookupFuncName(list_make1(makeString(modelLookupFuncName)), 3, modelLookupArgTypes, false);
-    if (!OidIsValid(modelLookupFuncOid)) {
-        elog(ERROR, "Function %s not found", modelLookupFuncName);
-        return;
-    }
+	Oid			modelLookupFuncOid = LookupFuncName(list_make1(makeString(modelLookupFuncName)), 3, modelLookupArgTypes, false);
 
-    fmgr_info(modelLookupFuncOid, &modelLookupFmgrInfo);
-    InitFunctionCallInfoData(*modelLookupFCInfo, &modelLookupFmgrInfo, 3, InvalidOid, NULL, NULL);
+	if (!OidIsValid(modelLookupFuncOid))
+	{
+		elog(ERROR, "Function %s not found", modelLookupFuncName);
+		return;
+	}
 
-    // split columns into an array of text
-    List *trainColumnsList = split_columns(trainColumns);
-    int nTrainColumns = list_length(trainColumnsList);
+	fmgr_info(modelLookupFuncOid, &modelLookupFmgrInfo);
+	InitFunctionCallInfoData(*modelLookupFCInfo, &modelLookupFmgrInfo, MODEL_LOOKUP_PARAMS_ARRAY_SIZE, InvalidOid, NULL, NULL);
 
-    Datum *trainColumnDatums = (Datum *) palloc(sizeof(Datum) * nTrainColumns);
-    for (int i = 0; i < nTrainColumns; i++) {
-        trainColumnDatums[i] = CStringGetTextDatum(strVal(list_nth(trainColumnsList, i)));
-    }
-    ArrayType *trainColumnArray = construct_array(trainColumnDatums, nTrainColumns, TEXTOID, -1, false, 'i');
+	/* split columns into an array of text */
+	List	   *trainColumnsList = split_columns(trainColumns);
+	int			nTrainColumns = list_length(trainColumnsList);
 
-    modelLookupFCInfo->args[0].value = CStringGetTextDatum(table);
-    modelLookupFCInfo->args[1].value = PointerGetDatum(trainColumnArray);
-    modelLookupFCInfo->args[2].value = CStringGetTextDatum(targetColumn);
+	Datum	   *trainColumnDatums = (Datum *) palloc(sizeof(Datum) * nTrainColumns);
 
-    modelLookupResult = FunctionCallInvoke(modelLookupFCInfo);
-    int modelId = 0;
-    // modelLookupResult is a boolean
-    if (!modelLookupFCInfo->isnull) {
-        modelId = DatumGetInt32(modelLookupResult);
-    }
+	for (int i = 0; i < nTrainColumns; i++)
+	{
+		trainColumnDatums[i] = CStringGetTextDatum(strVal(list_nth(trainColumnsList, i)));
+	}
+	ArrayType  *trainColumnArray = construct_array(trainColumnDatums, nTrainColumns, TEXTOID, -1, false, 'i');
 
-    if (modelId == 0) {
-        // model does not exist, training
-        FmgrInfo trainingFmgrInfo;
-        LOCAL_FCINFO(trainingFCInfo, FUNC_MAX_ARGS); // fcinfo for training function
+	modelLookupFCInfo->args[0].value = CStringGetTextDatum(table);
+	modelLookupFCInfo->args[1].value = PointerGetDatum(trainColumnArray);
+	modelLookupFCInfo->args[2].value = CStringGetTextDatum(targetColumn);
 
-        // TODO: These parameters should be passed in as arguments, hard-coded for now
-        char modelName[] = "armnet";
-        int batch_size = 4096;
-        int batch_num = 80;
-        int nfeat = 5500;
-        int epoch = 1;
+	modelLookupResult = FunctionCallInvoke(modelLookupFCInfo);
+	int			modelId = 0;
 
-        Datum trainingResult;
+	/* modelLookupResult is a boolean */
+	if (!modelLookupFCInfo->isnull)
+	{
+		modelId = DatumGetInt32(modelLookupResult);
+	}
 
-        Oid trainingArgTypes[8] = {TEXTOID, TEXTOID, INT4OID, INT4OID, INT4OID, INT4OID, TEXTARRAYOID, TEXTOID};
-        char trainingFuncName[] = "nr_train";
+	if (modelId == 0)
+	{
+		/* model does not exist, training */
+		FmgrInfo	trainingFmgrInfo;
 
-        Oid trainingFuncOid = LookupFuncName(list_make1(makeString(trainingFuncName)), 8, trainingArgTypes, false);
-        if (!OidIsValid(trainingFuncOid)) {
-            elog(ERROR, "Function %s not found", trainingFuncName);
-            return;
-        }
+		/* fcinfo for training function */
+		LOCAL_FCINFO(trainingFCInfo, FUNC_MAX_ARGS);
+		Datum		trainingResult;
 
-        fmgr_info(trainingFuncOid, &trainingFmgrInfo);
-        InitFunctionCallInfoData(*trainingFCInfo, &trainingFmgrInfo, 8, InvalidOid, NULL, NULL);
+		Oid			trainingFuncOid = LookupFuncName(list_make1(makeString(trainingFuncName)), 8, trainingArgTypes, false);
 
-        trainingFCInfo->args[0].value = CStringGetTextDatum(modelName);
-        trainingFCInfo->args[1].value = CStringGetTextDatum(table);
-        trainingFCInfo->args[2].value = Int32GetDatum(batch_size);
-        trainingFCInfo->args[3].value = Int32GetDatum(batch_num);
-        trainingFCInfo->args[4].value = Int32GetDatum(epoch);
-        trainingFCInfo->args[5].value = Int32GetDatum(nfeat);
-        trainingFCInfo->args[6].value = PointerGetDatum(trainColumnArray);
-        trainingFCInfo->args[7].value = CStringGetTextDatum(targetColumn);
+		if (!OidIsValid(trainingFuncOid))
+		{
+			elog(ERROR, "Function %s not found", trainingFuncName);
+			return;
+		}
 
-        trainingFCInfo->args[0].isnull = false;
-        trainingFCInfo->args[1].isnull = false;
-        trainingFCInfo->args[2].isnull = false;
-        trainingFCInfo->args[3].isnull = false;
-        trainingFCInfo->args[4].isnull = false;
-        trainingFCInfo->args[5].isnull = false;
-        trainingFCInfo->args[6].isnull = false;
-        trainingFCInfo->args[7].isnull = false;
+		fmgr_info(trainingFuncOid, &trainingFmgrInfo);
+		InitFunctionCallInfoData(*trainingFCInfo, &trainingFmgrInfo, 8, InvalidOid, NULL, NULL);
 
-        trainingResult = FunctionCallInvoke(trainingFCInfo);
-        if (!trainingFCInfo->isnull) {
-            text *resultText = DatumGetTextP(trainingResult);
-            char *resultCString = text_to_cstring(resultText);
-            elog(INFO, "Training result: %s", resultCString);
-            pfree(resultCString);
-        } else {
-            elog(INFO, "Training result is NULL");
-        }
-    } else {
-        // inference
-        FmgrInfo inferenceFmgrInfo;
-        LOCAL_FCINFO(inferenceFCInfo, FUNC_MAX_ARGS); // fcinfo for inference function
+		trainingFCInfo->args[0].value = CStringGetTextDatum(NRModelName);
+		trainingFCInfo->args[1].value = CStringGetTextDatum(table);
+		trainingFCInfo->args[2].value = Int32GetDatum(NRTaskBatchSize);
+		trainingFCInfo->args[3].value = Int32GetDatum(NRTaskNumBatches);
+		trainingFCInfo->args[4].value = Int32GetDatum(NRTaskEpoch);
+		trainingFCInfo->args[5].value = Int32GetDatum(NRTaskMaxFeatures);
+		trainingFCInfo->args[6].value = PointerGetDatum(trainColumnArray);
+		trainingFCInfo->args[7].value = CStringGetTextDatum(targetColumn);
 
-        // TODO: These parameters should be passed in as arguments, hard-coded for now
-        char modelName[] = "armnet";
-        int batch_size = 100;
-        int batch_num = 4;
-        int nfeat = 5500;
+        set_false_to_all_params(trainingFCInfo->args, TRAINING_PARAMS_ARRAY_SIZE);
 
-        Datum inferenceResult;
-        Oid inferenceArgTypes[7] = {TEXTOID, INT4OID, TEXTOID, INT4OID, INT4OID, INT4OID, TEXTARRAYOID};
-        char inferenceFuncName[] = "nr_inference";
+		trainingResult = FunctionCallInvoke(trainingFCInfo);
+		if (!trainingFCInfo->isnull)
+		{
+			text	   *resultText = DatumGetTextP(trainingResult);
+			char	   *resultCString = text_to_cstring(resultText);
 
-        Oid inferenceFuncOid = LookupFuncName(list_make1(makeString(inferenceFuncName)), 7, inferenceArgTypes, false);
-        if (!OidIsValid(inferenceFuncOid)) {
-            elog(ERROR, "Function %s not found", inferenceFuncName);
-            return;
-        }
+			elog(INFO, "Training result: %s", resultCString);
+			pfree(resultCString);
+		}
+		else
+		{
+			elog(INFO, "Training result is NULL");
+		}
+	}
+	else
+	{
+		/* inference */
+		FmgrInfo	inferenceFmgrInfo;
 
-        fmgr_info(inferenceFuncOid, &inferenceFmgrInfo);
-        InitFunctionCallInfoData(*inferenceFCInfo, &inferenceFmgrInfo, 7, InvalidOid, NULL, NULL);
+		/* fcinfo for inference function */
+		LOCAL_FCINFO(inferenceFCInfo, FUNC_MAX_ARGS);
+		Datum		inferenceResult;
 
-        inferenceFCInfo->args[0].value = CStringGetTextDatum(modelName);
-        inferenceFCInfo->args[1].value = Int32GetDatum(modelId);
-        inferenceFCInfo->args[2].value = CStringGetTextDatum(table);
-        inferenceFCInfo->args[3].value = Int32GetDatum(batch_size);
-        inferenceFCInfo->args[4].value = Int32GetDatum(batch_num);
-        inferenceFCInfo->args[5].value = Int32GetDatum(nfeat);
-        inferenceFCInfo->args[6].value = PointerGetDatum(trainColumnArray);
+		Oid			inferenceFuncOid = LookupFuncName(list_make1(makeString(inferenceFuncName)), 7, inferenceArgTypes, false);
 
-        inferenceFCInfo->args[0].isnull = false;
-        inferenceFCInfo->args[1].isnull = false;
-        inferenceFCInfo->args[2].isnull = false;
-        inferenceFCInfo->args[3].isnull = false;
-        inferenceFCInfo->args[4].isnull = false;
-        inferenceFCInfo->args[5].isnull = false;
-        inferenceFCInfo->args[6].isnull = false;
+		if (!OidIsValid(inferenceFuncOid))
+		{
+			elog(ERROR, "Function %s not found", inferenceFuncName);
+			return;
+		}
 
-        inferenceResult = FunctionCallInvoke(inferenceFCInfo);
-        if (!inferenceFCInfo->isnull) {
-            text *resultText = DatumGetTextP(inferenceResult);
-            char *resultCString = text_to_cstring(resultText);
-            elog(INFO, "Inference result: %s", resultCString);
-            pfree(resultCString);
-        } else {
-            elog(INFO, "Inference result is NULL");
-        }
-    }
+		fmgr_info(inferenceFuncOid, &inferenceFmgrInfo);
+		InitFunctionCallInfoData(*inferenceFCInfo, &inferenceFmgrInfo, 7, InvalidOid, NULL, NULL);
+
+		inferenceFCInfo->args[0].value = CStringGetTextDatum(NRModelName);
+		inferenceFCInfo->args[1].value = Int32GetDatum(modelId);
+		inferenceFCInfo->args[2].value = CStringGetTextDatum(table);
+		inferenceFCInfo->args[3].value = Int32GetDatum(NRTaskBatchSize);
+		inferenceFCInfo->args[4].value = Int32GetDatum(NRTaskNumBatches);
+		inferenceFCInfo->args[5].value = Int32GetDatum(NRTaskMaxFeatures);
+		inferenceFCInfo->args[6].value = PointerGetDatum(trainColumnArray);
+
+        set_false_to_all_params(inferenceFCInfo->args, INFERENCE_PARAMS_ARRAY_SIZE);
+
+		inferenceResult = FunctionCallInvoke(inferenceFCInfo);
+		if (!inferenceFCInfo->isnull)
+		{
+			text	   *resultText = DatumGetTextP(inferenceResult);
+			char	   *resultCString = text_to_cstring(resultText);
+
+			elog(INFO, "Inference result: %s", resultCString);
+			pfree(resultCString);
+		}
+		else
+		{
+			elog(INFO, "Inference result is NULL");
+		}
+	}
 }
 
 /*
@@ -194,64 +223,85 @@ exec_udf(const char *table, const char *trainColumns, const char *targetColumn, 
 * NeurDBPredictStmt: Node structure in include/nodes/parsenodes.h
 */
 ObjectAddress
-ExecPredictStmt(NeurDBPredictStmt *stmt, ParseState *pstate, const char *whereClauseString) {
-    ListCell *cell;
-    StringInfoData targetColumn;
-    StringInfoData trainOnColumns;
-    char *tableName = NULL;
-    char *whereClause = "<DEPRECATED>";
+ExecPredictStmt(NeurDBPredictStmt * stmt, ParseState *pstate, const char *whereClauseString)
+{
+	ListCell   *cell;
+	StringInfoData targetColumn;
+	StringInfoData trainOnColumns;
+	char	   *tableName = NULL;
+	char	   *whereClause = "<DEPRECATED>";
 
-    initStringInfo(&targetColumn);
-    initStringInfo(&trainOnColumns);
+	initStringInfo(&targetColumn);
+	initStringInfo(&trainOnColumns);
 
-    /* Extract the column names from targetList and combine them into a single string */
-    foreach(cell, stmt->targetList) {
-        ResTarget *res = (ResTarget *) lfirst(cell);
-        if (res == NULL || res->val == NULL) {
-            elog(ERROR, "Null target column in statement");
-            return InvalidObjectAddress;
-        }
-        char *colname = FigureColname(res->val);
-        if (colname == NULL) {
-            elog(ERROR, "Null column name in target list");
-            return InvalidObjectAddress;
-        }
-        appendStringInfo(&targetColumn, "%s", colname);
-    }
-    targetColumn.data[targetColumn.len] = '\0';
+	/*
+	 * Extract the column names from targetList and combine them into a single
+	 * string
+	 */
+	foreach(cell, stmt->targetList)
+	{
+		ResTarget  *res = (ResTarget *) lfirst(cell);
 
-    /* Extract the table name from fromClause */
-    if (stmt->fromClause != NIL) {
-        RangeVar *rv = (RangeVar *) linitial(stmt->fromClause);
-        if (rv == NULL) {
-            elog(ERROR, "Null range variable in from clause");
-            return InvalidObjectAddress;
-        }
-        tableName = rv->relname;
-        elog(DEBUG1, "Extracted table name: %s", tableName);
-    } else {
-        elog(ERROR, "No from clause in statement");
-        return InvalidObjectAddress;
-    }
+		if (res == NULL || res->val == NULL)
+		{
+			elog(ERROR, "Null target column in statement");
+			return InvalidObjectAddress;
+		}
+		char	   *colname = FigureColname(res->val);
 
-    /* Extract the TrainOnSpec */
-    if (stmt->trainOnSpec != NULL) {
-        NeurDBTrainOnSpec *trainOnSpec = (NeurDBTrainOnSpec *) stmt->trainOnSpec;
-        foreach(cell, trainOnSpec->trainOn) {
-            Node *columnName = (Node *) lfirst(cell);
-            if (columnName->type == T_A_Star) {
-                elog(DEBUG1, "Train on all columns");
-                break;
-            }
-            appendStringInfo(&trainOnColumns, "%s,", strVal(columnName));
-        }
-    } else {
-        elog(DEBUG1, "No TrainOnSpec provided");
-    }
-    trainOnColumns.data[trainOnColumns.len - 1] = '\0';
+		if (colname == NULL)
+		{
+			elog(ERROR, "Null column name in target list");
+			return InvalidObjectAddress;
+		}
+		appendStringInfo(&targetColumn, "%s", colname);
+	}
+	targetColumn.data[targetColumn.len] = '\0';
 
-    /* Execute the UDF with extracted columns, table name, and where clause */
-    exec_udf(tableName, trainOnColumns.data, targetColumn.data, whereClause);
+	/* Extract the table name from fromClause */
+	if (stmt->fromClause != NIL)
+	{
+		RangeVar   *rv = (RangeVar *) linitial(stmt->fromClause);
 
-    return InvalidObjectAddress;
+		if (rv == NULL)
+		{
+			elog(ERROR, "Null range variable in from clause");
+			return InvalidObjectAddress;
+		}
+		tableName = rv->relname;
+		elog(DEBUG1, "Extracted table name: %s", tableName);
+	}
+	else
+	{
+		elog(ERROR, "No from clause in statement");
+		return InvalidObjectAddress;
+	}
+
+	/* Extract the TrainOnSpec */
+	if (stmt->trainOnSpec != NULL)
+	{
+		NeurDBTrainOnSpec *trainOnSpec = (NeurDBTrainOnSpec *) stmt->trainOnSpec;
+
+		foreach(cell, trainOnSpec->trainOn)
+		{
+			Node	   *columnName = (Node *) lfirst(cell);
+
+			if (columnName->type == T_A_Star)
+			{
+				elog(DEBUG1, "Train on all columns");
+				break;
+			}
+			appendStringInfo(&trainOnColumns, "%s,", strVal(columnName));
+		}
+	}
+	else
+	{
+		elog(DEBUG1, "No TrainOnSpec provided");
+	}
+	trainOnColumns.data[trainOnColumns.len - 1] = '\0';
+
+	/* Execute the UDF with extracted columns, table name, and where clause */
+	exec_udf(tableName, trainOnColumns.data, targetColumn.data, whereClause);
+
+	return InvalidObjectAddress;
 }

--- a/dbengine/src/backend/utils/misc/guc_tables.c
+++ b/dbengine/src/backend/utils/misc/guc_tables.c
@@ -3865,7 +3865,7 @@ struct config_string ConfigureNamesString[] =
 		},
 		&NRModelName,
 		"armnet",
-		NULL, NULL, show_archive_command
+		NULL, NULL, NULL
 	},
 
 	{

--- a/dbengine/src/include/commands/predict.h
+++ b/dbengine/src/include/commands/predict.h
@@ -18,5 +18,14 @@
 #include "nodes/parsenodes.h"
 #include "parser/parse_node.h"
 
+/*
+ * GUC variable for current configuration
+ */
+extern PGDLLIMPORT char *NRModelName;
+extern PGDLLIMPORT int NRTaskBatchSize;
+extern PGDLLIMPORT int NRTaskEpoch;
+extern PGDLLIMPORT int NRTaskMaxFeatures;
+extern PGDLLIMPORT int NRTaskNumBatches;
+
 extern ObjectAddress ExecPredictStmt(NeurDBPredictStmt * stmt, ParseState *pstate, const char *whereClauseString);
 #endif							/* PREDICT_H */

--- a/dbengine/src/include/utils/guc_tables.h
+++ b/dbengine/src/include/utils/guc_tables.h
@@ -55,6 +55,8 @@ typedef struct config_var_value
 enum config_group
 {
 	UNGROUPED,					/* use for options not shown in pg_settings */
+	NEURDB_MODEL_OPTIONS,
+	NEURDB_RUNTIME_OPTIONS,
 	FILE_LOCATIONS,
 	CONN_AUTH_SETTINGS,
 	CONN_AUTH_TCP,
@@ -97,7 +99,7 @@ enum config_group
 	ERROR_HANDLING_OPTIONS,
 	PRESET_OPTIONS,
 	CUSTOM_OPTIONS,
-	DEVELOPER_OPTIONS
+	DEVELOPER_OPTIONS,
 };
 
 /*


### PR DESCRIPTION
This PR finishes the database core side of using runtime parameters to control the training/inference process. It still requires the other parts to use these parameters before it actually works.

Currently available parameters are:
- nr_model_name
- nr_task_batch_size
- nr_task_epoch
- nr_task_max_features
- nr_task_num_batches

@TsukiSky We may need to modify *nr_pipeline* to recognize these parameters.

## Naming Convention

As to unify the naming of parameters, we can use a naming style similar to how PostgreSQL adopts.

- Add an `nr` prefix (dedicated to all NeurDB-related parameters)
- Specify the affected entity group, e.g., `log`, `event`. Can use abbreviation here, e.g., `lc` means locale.
- Specify the detailed setting, e.g., `strategy`, `isolation`. Use noun.
- Optionally postfixing with inheriting parameters for subtasks, e.g., `train`, `test`, `inference`, `finetune.`

## Example

- `nr_model_name` (`nr`, `model`, `name`): Set the name of the using model
- `nr_task_batch_size` (`nr`, `task`, `batch_size`): Set the batch size for ML tasks
- `nr_task_batch_size_train` (`nr`, `task`, `batch_size`, `train`): Set the batch size for ML training tasks. If not set, the value is inherited from `nr_task_batch_size`.