### PR TITLE
Feat: Allow setting model on the fly

### DIFF
--- a/.github/workflows/docker-build-dev.yml
+++ b/.github/workflows/docker-build-dev.yml
@@ -21,6 +21,8 @@ jobs:
     name: Build Docker Images
     # Runner to use
     runs-on: ubuntu-latest
+    # Timeout
+    timeout-minutes: 5
 
     steps:
     - name: Checkout

--- a/aiengine/runtime/neurdbrt/model/__init__.py
+++ b/aiengine/runtime/neurdbrt/model/__init__.py
@@ -1,9 +1,11 @@
 from .armnet import *
 from .base import *
 from .mlp_clf import *
-
+from ..log import logger
 
 def build_model(model_name: str, config_args) -> BuilderBase:
+    logger.info("building model", model_name=model_name)
+    
     model = None
     if model_name == "armnet":
         model = ARMNetModelBuilder(config_args)

--- a/aiengine/runtime/neurdbrt/model/__init__.py
+++ b/aiengine/runtime/neurdbrt/model/__init__.py
@@ -1,11 +1,12 @@
+from ..log import logger
 from .armnet import *
 from .base import *
 from .mlp_clf import *
-from ..log import logger
+
 
 def build_model(model_name: str, config_args) -> BuilderBase:
     logger.info("building model", model_name=model_name)
-    
+
     model = None
     if model_name == "armnet":
         model = ARMNetModelBuilder(config_args)

--- a/aiengine/runtime/neurdbrt/model/armnet/requirements.txt
+++ b/aiengine/runtime/neurdbrt/model/armnet/requirements.txt
@@ -1,5 +1,5 @@
-# run with pip install torch==1.6.0 --timeout 100 if above failed.
-torch==1.6.0
+# run with pip install torch==2.2.0 --timeout 100 if above failed.
+torch==2.2.0
 torchaudio==0.6.0
 torchinfo==0.3.1
 torchvision==0.7.0

--- a/dbengine/src/backend/commands/predict.c
+++ b/dbengine/src/backend/commands/predict.c
@@ -192,7 +192,7 @@ exec_udf(const char *model, const char *table, const char *trainColumns, const c
 		fmgr_info(inferenceFuncOid, &inferenceFmgrInfo);
 		InitFunctionCallInfoData(*inferenceFCInfo, &inferenceFmgrInfo, 7, InvalidOid, NULL, NULL);
 
-		inferenceFCInfo->args[0].value = CStringGetTextDatum(NRModelName);
+		inferenceFCInfo->args[0].value = CStringGetTextDatum(model);
 		inferenceFCInfo->args[1].value = Int32GetDatum(modelId);
 		inferenceFCInfo->args[2].value = CStringGetTextDatum(table);
 		inferenceFCInfo->args[3].value = Int32GetDatum(NRTaskBatchSize);
@@ -296,14 +296,14 @@ ExecPredictStmt(NeurDBPredictStmt * stmt, ParseState *pstate, const char *whereC
 			appendStringInfo(&trainOnColumns, "%s,", strVal(columnName));
 		}
 
-		if (trainOnSpec->modelName != NULL)
+		if (strlen(trainOnSpec->modelName) > 0)
 		{
-			elog(DEBUG1, "User specified model name: %s", trainOnSpec->modelName);
+			elog(WARNING, "User specified model name: %s", trainOnSpec->modelName);
 			modelName = trainOnSpec->modelName;
 		}
 		else
 		{
-			elog(DEBUG1, "No model name provided. Use config NRModelName: %s", NRModelName);
+			elog(WARNING, "No model name provided. Use config NRModelName: %s", NRModelName);
 			modelName = NRModelName;
 		}
 	}

--- a/dbengine/src/include/nodes/parsenodes.h
+++ b/dbengine/src/include/nodes/parsenodes.h
@@ -4054,35 +4054,37 @@ typedef struct DropSubscriptionStmt
 
 typedef struct NeurDBTrainOnSpec
 {
-  NodeTag 		type;      /* Node type identifier */
+	NodeTag		type;			/* Node type identifier */
 
-  List 			*trainOn;     /* Columns used to train the model */
-  Node 			*trainOnWith; /* Filtering data. Same as WHERE clause before (and that in
-                        SELECT) */
-} NeurDBTrainOnSpec;
+	List	   *trainOn;		/* Columns used to train the model */
+	char	   *modelName;		/* Model name */
+	Node	   *trainOnWith;	/* Filtering data. Same as WHERE clause before
+								 * (and that in SELECT) */
+}			NeurDBTrainOnSpec;
 
 typedef enum PredictType
 {
-  PREDICT_CLASS, /* Classification prediction. */
-  PREDICT_VALUE  /* Value prediction. */
-} PredictType;
+	PREDICT_CLASS,				/* Classification prediction. */
+	PREDICT_VALUE				/* Value prediction. */
+}			PredictType;
 
 typedef struct NeurDBPredictStmt
 {
-  	NodeTag 	type;      /* Node type identifier */
+	NodeTag		type;			/* Node type identifier */
 
-  	PredictType kind;  /* Task type (classification or value
-                      * prediction) */
-  	List 		*targetList;  /* A list of targets (columns) for the
-                      * prediction */
-  	List 		*fromClause;  /* A list of tables involved in the prediction */
-  	Node 		*trainOnSpec;     /* Sepc for the TRAIN ON syntax */
-  	SelectStmt 	*values;    /* Values (following definition of 'values_clause' symbol) */
-} NeurDBPredictStmt;
+	PredictType kind;			/* Task type (classification or value
+								 * prediction) */
+	List	   *targetList;		/* A list of targets (columns) for the
+								 * prediction */
+	List	   *fromClause;		/* A list of tables involved in the prediction */
+	NeurDBTrainOnSpec *trainOnSpec; /* Sepc for the TRAIN ON syntax */
+	SelectStmt *values;			/* Values (following definition of
+								 * 'values_clause' symbol) */
+}			NeurDBPredictStmt;
 
 #endif							/* PARSENODES_H */
 
 #if 0
-Node *whereClause; /* The WHERE clause for filtering data */
-bool allowTrain;   /* Let DB train a model if it does not exist? */
+Node	   *whereClause;		/* The WHERE clause for filtering data */
+bool		allowTrain;			/* Let DB train a model if it does not exist? */
 #endif


### PR DESCRIPTION
This PR allows the user to specify a model when writing a `PREDICT` query.

The syntax is now extended from
```
PREDICT VALUE OF ... 
TRAIN ON [column_names | '*']
```
to
```
PREDICT VALUE OF ... 
TRAIN [model_name] ON [column_names | '*']
```

The new syntax is backward-compatible with the old one. Without directly specifying `model_name`, the DB engine uses the config `nr_model_name`, which is default to `armnet`.