### PR TITLE
fix: docker building

### DIFF
--- a/dbengine/nr_kernel/nr_ext/src/nr_executor.c
+++ b/dbengine/nr_kernel/nr_ext/src/nr_executor.c
@@ -13,7 +13,7 @@
 #include "utils/snapmgr.h"
 
 #include "parser/parse_node.h"
-#include "commands/predict.h"
+#include "predict.h"
 
 /* required metadata marker for PostgreSQL extensions */
 PG_MODULE_MAGIC;

--- a/docker-init.sh
+++ b/docker-init.sh
@@ -49,8 +49,10 @@ $NR_PSQL_PATH/bin/pg_ctl -D $NR_DBDATA_PATH -l logfile start
 
 # Wait a few seconds to ensure DB engine is up and running
 until $NR_PSQL_PATH/bin/psql -h localhost -p 5432 -U neurdb -c '\q'; do
-  >&2 echo 'Postgres is unavailable - sleeping'
+  >&2 echo 'NeurDB is unavailable - sleeping'
   sleep 1
+  # try to create `neurdb` database into the cluster
+  $NR_PSQL_PATH/bin/createdb -h localhost -p 5432 neurdb
 done
 echo "DB Started!"
 


### PR DESCRIPTION
This PR fixes an issue where the `neurdb` database may not be created in the cluster, so that `docker-init.sh` always waits for the cluster to start without progress.