### PR TITLE
feat(aiengine): model pool, lifecycle hooks & dynamic model registration

### DIFF
--- a/aiengine/runtime/neurdbrt/app/setup.py
+++ b/aiengine/runtime/neurdbrt/app/setup.py
@@ -35,9 +35,10 @@ class Setup:
             nfields, nfeat = self.libsvm_data.setup_for_train_task(
                 train_batch_num, eva_batch_num, test_batch_num
             )
+            self._args.nfields = nfields
+            self._args.nfeat = nfeat
 
             builder = build_model(self._model_name, self._args)
-            builder.model_dimension = (nfeat, nfields)
             await builder.train(
                 self.libsvm_data,
                 self.libsvm_data,
@@ -71,6 +72,8 @@ class Setup:
             nfields, nfeat = self.libsvm_data.setup_for_train_task(
                 train_batch_num, eva_batch_num, test_batch_num
             )
+            self._args.nfields = nfields
+            self._args.nfeat = nfeat
 
             try:
                 builder = build_model(self._model_name, self._args)
@@ -84,7 +87,6 @@ class Setup:
                     layer.requires_grad_(False)
 
             builder.model = model.to(DEVICE)
-            builder.model_dimension = (nfeat, nfields)
             await builder.train(
                 self.libsvm_data,
                 self.libsvm_data,

--- a/aiengine/runtime/neurdbrt/hook.py
+++ b/aiengine/runtime/neurdbrt/hook.py
@@ -1,0 +1,74 @@
+"""
+Supporting lifecycle hooks.
+
+Any modules within the `model` module will be checked by finding a list of hook
+functions, and these functions will be executed during specific events.
+
+Available hooks:
+    neurdb_on_start(): executed when the AI engine starts
+"""
+
+import importlib
+import pkgutil
+from typing import Callable, List
+
+from neurdbrt.log import logger
+
+
+_on_start_hooks: List[Callable[[], None]] = []
+
+
+def _find_child_modules(module_path) -> List[str]:
+    """
+    Find all child modules within a given module or package.
+
+    Args:
+        module_path (str): The name of the module or package (e.g., 'mypackage').
+
+    Returns:
+        list: List of submodule names.
+    """
+    try:
+        # Import the module/package
+        module = importlib.import_module(module_path)
+        # Get the path to the module/package
+        module_dir = module.__path__ if hasattr(module, "__path__") else None
+
+        if module_dir:
+            # Iterate over all modules in the package
+            return [name for _, name, _ in pkgutil.iter_modules(module_dir)]
+        else:
+            return []  # Not a package, so no child modules
+
+    except ImportError:
+        logger.error(f"Module {module_path} not found")
+        return []
+
+
+def register_hooks():
+    """
+    Register all hooks.
+    """
+    BASE_MODULE = "neurdbrt.model"
+    
+    modules = _find_child_modules(BASE_MODULE)
+    for module_name in modules:
+        try:
+            # Import the module
+            mod = importlib.import_module(f"{BASE_MODULE}.{module_name}")
+        except ImportError:
+            logger.error(f"Module {module_name} not found")
+            continue
+
+        for hook in dir(mod):
+            if hook == "neurdb_on_start":
+                _on_start_hooks.append(getattr(mod, hook))
+                logger.info(f"Registered hook: {hook} from {module_name}")
+
+
+def exec_hooks_on_start():
+    """
+    Execute all registered hooks.
+    """
+    for hook in _on_start_hooks:
+        hook()

--- a/aiengine/runtime/neurdbrt/hook.py
+++ b/aiengine/runtime/neurdbrt/hook.py
@@ -14,7 +14,6 @@ from typing import Callable, List
 
 from neurdbrt.log import logger
 
-
 _on_start_hooks: List[Callable[[], None]] = []
 
 
@@ -50,7 +49,7 @@ def register_hooks():
     Register all hooks.
     """
     BASE_MODULE = "neurdbrt.model"
-    
+
     modules = _find_child_modules(BASE_MODULE)
     for module_name in modules:
         try:

--- a/aiengine/runtime/neurdbrt/model/__init__.py
+++ b/aiengine/runtime/neurdbrt/model/__init__.py
@@ -1,12 +1,15 @@
 from typing import Type
+
 from ..log import logger
 from .base import *
 
 _name_builder_map = {}
 
+
 def register_model(model_name: str, builder: Type[BuilderBase]):
     logger.info("registering model", model_name=model_name)
     _name_builder_map[model_name] = builder
+
 
 def build_model(model_name: str, config_args) -> BuilderBase:
     logger.info("building model", model_name=model_name)
@@ -14,5 +17,5 @@ def build_model(model_name: str, config_args) -> BuilderBase:
     builder = _name_builder_map.get(model_name)
     if not builder:
         raise ValueError(f"model {model_name} not found")
-    
+
     return builder(config_args)

--- a/aiengine/runtime/neurdbrt/model/__init__.py
+++ b/aiengine/runtime/neurdbrt/model/__init__.py
@@ -1,15 +1,18 @@
+from typing import Type
 from ..log import logger
-from .armnet import *
 from .base import *
-from .mlp_clf import *
 
+_name_builder_map = {}
+
+def register_model(model_name: str, builder: Type[BuilderBase]):
+    logger.info("registering model", model_name=model_name)
+    _name_builder_map[model_name] = builder
 
 def build_model(model_name: str, config_args) -> BuilderBase:
     logger.info("building model", model_name=model_name)
 
-    model = None
-    if model_name == "armnet":
-        model = ARMNetModelBuilder(config_args)
-    # if model_name == "mlp":
-    # model = MLPBuilder(config_args)
-    return model
+    builder = _name_builder_map.get(model_name)
+    if not builder:
+        raise ValueError(f"model {model_name} not found")
+    
+    return builder(config_args)

--- a/aiengine/runtime/neurdbrt/model/armnet/__init__.py
+++ b/aiengine/runtime/neurdbrt/model/armnet/__init__.py
@@ -1,2 +1,7 @@
 from .builder import *
 from .model import *
+
+from neurdbrt.model import register_model
+
+def neurdb_on_start():
+    register_model("armnet", ARMNetModelBuilder)

--- a/aiengine/runtime/neurdbrt/model/armnet/__init__.py
+++ b/aiengine/runtime/neurdbrt/model/armnet/__init__.py
@@ -1,7 +1,8 @@
+from neurdbrt.model import register_model
+
 from .builder import *
 from .model import *
 
-from neurdbrt.model import register_model
 
 def neurdb_on_start():
     register_model("armnet", ARMNetModelBuilder)

--- a/aiengine/runtime/neurdbrt/model/armnet/builder.py
+++ b/aiengine/runtime/neurdbrt/model/armnet/builder.py
@@ -23,8 +23,8 @@ class ARMNetModelBuilder(BuilderBase):
         print(f"[_init_model_arch]: Moving model to {DEVICE}")
         if self._model is None:
             self._model = ARMNetModel(
-                self._nfield if self._nfield else self.args.nfield,
-                self._nfeat if self._nfeat else self.args.nfeat,
+                self.args.nfields,
+                self.args.nfeat,
                 self.args.nemb,
                 self.args.nattn_head,
                 self.args.alpha,
@@ -49,7 +49,6 @@ class ARMNetModelBuilder(BuilderBase):
     ):
         logger = self._logger.bind(task="train")
 
-        # _nfeat, _nfield = self.model_dimension
         # create model
         self._init_model_arch()
 

--- a/aiengine/runtime/neurdbrt/model/base/builder.py
+++ b/aiengine/runtime/neurdbrt/model/base/builder.py
@@ -15,8 +15,6 @@ class BuilderBase(ABC):
 
     def __init__(self):
         self._model: nn.Module = None
-        self._nfeat = None
-        self._nfield = None
 
     @property
     def model(self) -> nn.Module:
@@ -25,25 +23,6 @@ class BuilderBase(ABC):
     @model.setter
     def model(self, value):
         self._model = value
-
-    @property
-    def model_dimension(self):
-        """
-        Get the model dimensions.
-        @return: A tuple containing (nfeat, nfield)
-        """
-        return self._nfeat, self._nfield
-
-    @model_dimension.setter
-    def model_dimension(self, dimensions):
-        """
-        Set the model dimensions.
-        @param dimensions: A tuple containing (nfeat, nfield)
-        @return: None
-        """
-        nfeat, nfield = dimensions
-        self._nfeat = nfeat
-        self._nfield = nfield
 
     @abstractmethod
     async def train(

--- a/aiengine/runtime/server.py
+++ b/aiengine/runtime/server.py
@@ -3,7 +3,6 @@ import json
 from threading import Thread
 from typing import Any, List
 
-from neurdbrt.hook import exec_hooks_on_start, register_hooks
 from neurdb.logger import configure_logging as api_configure_logging
 from neurdbrt.app import Setup, WebsocketSender, before_execute
 from neurdbrt.app.msg import (
@@ -18,6 +17,7 @@ from neurdbrt.app.msg import (
 )
 from neurdbrt.cache import Bufferkey, ContextStates, DataCache, LibSvmDataDispatcher
 from neurdbrt.config import parse_config_arguments
+from neurdbrt.hook import exec_hooks_on_start, register_hooks
 from neurdbrt.log import configure_logging, logger
 from neurdbrt.repo import ModelRepository
 from quart import Quart, current_app, g, websocket
@@ -45,7 +45,7 @@ else:
             # "password": config_args.db_password,
         }
     )
-    
+
 register_hooks()
 exec_hooks_on_start()
 

--- a/aiengine/runtime/server.py
+++ b/aiengine/runtime/server.py
@@ -3,7 +3,7 @@ import json
 from threading import Thread
 from typing import Any, List
 
-import numpy as np
+from neurdbrt.hook import exec_hooks_on_start, register_hooks
 from neurdb.logger import configure_logging as api_configure_logging
 from neurdbrt.app import Setup, WebsocketSender, before_execute
 from neurdbrt.app.msg import (
@@ -31,7 +31,7 @@ quart_app = Quart(__name__)
 
 config_path = "./config.ini"
 config_args = parse_config_arguments(config_path)
-print(config_args)
+logger.info(config_args)
 
 if config_args.run_model != "in_database":
     NEURDB_CONNECTOR = None
@@ -45,6 +45,9 @@ else:
             # "password": config_args.db_password,
         }
     )
+    
+register_hooks()
+exec_hooks_on_start()
 
 
 @quart_app.before_serving


### PR DESCRIPTION
## Summary

This PR is the first step towards a more extensible AI engine. It implements three mechanisms:
- A **model pool**, which is a map that holds all available model architectures. The user can specify different model architecture names to train/inference on different types of models on the fly.
- **Lifecycle hooks**. This adds flexible runtime behaviors to the AI engine. Currently, only one hook is implemented: `neurdb_on_start()`, which is called when the AI engine starts.
- **Dynamic model registration**. Based on lifecycle hooks, a Python module exposing specific functions can register itself to the model pool, and gets called when a new prediction task comes.

## Usage

Take ARM-Net as an example to show how to add a model architecture to the AI engine.

### Package the model architecture

Put the code implementing the model architecture under the `neurdbrt.model` module. The file tree will look like:

``` 
neurdbrt
├── model
│   ├── armnet    <- here
│   ├── mlp_clf
```

### Register the model by using lifecycle hook

For example, the code in `model/armnet/__init__.py` looks like:

```py
...

from neurdbrt.model import register_model

def neurdb_on_start():
    register_model("armnet", ARMNetModelBuilder)
```

It uses the `register_model()` function provided by the AI engine to register itself to the model pool. Then, when the user sets `NrModelName` as `armnet`, AI engine will instantiate `ARMNetModelBuilder` and call its interfaces such as `train()` or `inference()` to do the actual job.

### Hooks are automatically called to register the model architecture

This is done in `server.py`:

```py
from neurdbrt.hook import exec_hooks_on_start, register_hooks
...

register_hooks()
exec_hooks_on_start()
```