### PR TITLE
fix(nr_pipeline): PREDICT VALUE OF crash

### DIFF
--- a/dbengine/nr_kernel/nr_pipeline/src/interface.c
+++ b/dbengine/nr_kernel/nr_pipeline/src/interface.c
@@ -277,7 +277,13 @@ Datum nr_inference(PG_FUNCTION_ARGS) {
 
   NeurDBInferenceResult *result = palloc(sizeof(NeurDBInferenceResult));
   // TODO: infer the type of the result
-  result->typeoid = TEXTOID;
+  if (type == PREDICT_CLASS) {
+    result->typeoid = TEXTOID;
+  } else if (type == PREDICT_VALUE) {
+    result->typeoid = FLOAT8OID;
+  } else {
+    elog(ERROR, "Unsupported data type");
+  }
   result->result = presult;
   result->id_class_map = last_id_class_map;
 


### PR DESCRIPTION
https://github.com/neurdb/neurdb/issues/56#issuecomment-3124514797 should be fixed by this PR.

The crash occurs because we do not check and set NeurDBInferenceResult->type based on the argument in nr_inference().