### PR TITLE
chore: add script to enable auto_pipeline

### DIFF
--- a/script/enable_auto_pipeline.sh
+++ b/script/enable_auto_pipeline.sh
@@ -30,6 +30,7 @@ if [ ! -d "$PREFIX/model" ]; then
   temp_dir=`mktemp -d /tmp/neurdb-XXXXXXXX`
   git clone --depth 1 https://github.com/ctxpipe/ctxpipe $temp_dir
   mv $temp_dir/models/ctxpipe-3linear $PREFIX/model
+  rm -rf $temp_dir
   echo "Done."
 else
   echo "CtxPipe models already exists. Skipping download."


### PR DESCRIPTION
This PR adds a utility script to enable automated pipeline recommendation (auto_pipeline) in NeurDB if the external dependencies are not satisfied. The script will clone GTE-large and CtxPipe's agent models into the required destinations.