### PR TITLE
feat: WITH PRIMARY KEY for PREDICT clauses

### DIFF
--- a/dbengine/nr_kernel/Makefile
+++ b/dbengine/nr_kernel/Makefile
@@ -7,17 +7,13 @@ BUILD_DIR ?= $(NEURDBPATH)/build/nr_kernel
 SRC_DIR := $(CURDIR)
 
 # Default target: build all subprojects
-.PHONY: all $(SUBDIRS) install debug clean help sync
+.PHONY: all $(SUBDIRS) install debug clean help sync distclean
 
 # Sync source to build directory
 sync:
 	@echo "Syncing source to build directory..."
 	@mkdir -p $(BUILD_DIR)
 	@rsync -a --delete --exclude='*.o' --exclude='*.so' --exclude='build/' $(SRC_DIR)/ $(BUILD_DIR)/
-	@echo "Cleaning CMake caches..."
-	@find $(BUILD_DIR) -name "CMakeCache.txt" -delete 2>/dev/null || true
-	@find $(BUILD_DIR) -name "cmake_install.cmake" -delete 2>/dev/null || true
-	@find $(BUILD_DIR) -type d -name "CMakeFiles" -exec rm -rf {} + 2>/dev/null || true
 
 # Default 'all' target: sync then build in build dir
 all: sync
@@ -62,13 +58,20 @@ clean:
 		done \
 	fi
 
+distclean:
+	@echo "Cleaning CMake caches..."
+	@find $(BUILD_DIR) -name "CMakeCache.txt" -delete
+	@find $(BUILD_DIR) -name "cmake_install.cmake" -delete
+	@find $(BUILD_DIR) -type d -name "CMakeFiles" -exec rm -rf {} +
+
 # Help target to list available commands
 help:
 	@echo "Available targets:"
-	@echo "  all      - Sync and build all subprojects"
-	@echo "  install  - Sync and install all subprojects"
-	@echo "  debug    - Sync and debug all subprojects"
-	@echo "  clean    - Clean all subprojects"
-	@echo "  sync     - Sync source to build directory"
+	@echo "  all       - Sync and build all subprojects"
+	@echo "  install   - Sync and install all subprojects"
+	@echo "  debug     - Sync and debug all subprojects"
+	@echo "  clean     - Clean all subprojects"
+	@echo "  sync      - Sync source to build directory"
+	@echo "  distclean - Clean build directory"
 	@echo ""
 	@echo "Build directory: $(BUILD_DIR)"

--- a/dbengine/nr_kernel/nr_ext/src/nodePredict.c
+++ b/dbengine/nr_kernel/nr_ext/src/nodePredict.c
@@ -22,14 +22,7 @@
 #include "nodes/primnodes.h"
 #include "nodes/makefuncs.h"
 
-
-static char *trainingFuncName = "nr_train";
-#define TRAINING_PARAMS_ARRAY_SIZE 9
-static Oid	trainingArgTypes[TRAINING_PARAMS_ARRAY_SIZE] = {TEXTOID, TEXTOID, INT4OID, INT4OID, INT4OID, INT4OID, TEXTARRAYOID, TEXTOID, INT4OID};
-
-static char *inferenceFuncName = "nr_inference";
-#define INFERENCE_PARAMS_ARRAY_SIZE 9
-static Oid	inferenceArgTypes[INFERENCE_PARAMS_ARRAY_SIZE] = {TEXTOID, INT4OID, TEXTOID, INT4OID, INT4OID, INT4OID, TEXTARRAYOID, TEXTOID, INT4OID};
+#include "util.h"
 
 static char *initFuncName = "nr_pipeline_init";
 #define INIT_PARAMS_ARRAY_SIZE 10
@@ -38,7 +31,7 @@ static Oid	initArgTypes[INIT_PARAMS_ARRAY_SIZE] =
 	TEXTOID, //model name
 	TEXTOID, //table name
 	INT4OID, //batch size
-	INT4OID, //epoch (number of training epochs)
+	INT4OID, //epoch(number of training epochs)
 	INT4OID, //n_batches
 	INT4OID, //nfeat
 	TEXTARRAYOID, //feature names
@@ -68,28 +61,7 @@ static char *closeFuncName = "nr_pipeline_close";
 static Oid	closeArgTypes[CLOSE_PARAMS_ARRAY_SIZE] = {};
 
 
-static List *
-split_columns(const char *columns)
-{
-	List	   *result = NIL;
-	char	   *token = strtok(columns, ",");
-
-	while (token != NULL)
-	{
-		result = lappend(result, makeString(token));
-		token = strtok(NULL, ",");
-	}
-	return result;
-}
-
-static void
-set_false_to_all_params(NullableDatum *args, int size)
-{
-	for (int i = 0; i < size; i++)
-	{
-		args[i].isnull = false;
-	}
-}
+/* ------------------------ Result Cache Linked List ------------------------ */
 
 typedef struct result_node
 {
@@ -98,13 +70,23 @@ typedef struct result_node
 }			result_node;
 
 static void
-insert_result_to_cache(NeurDBPredictState * pstate, double value)
+push_result_to_cache(dclist_head *head, double value)
 {
 	result_node *node = palloc(sizeof(result_node));
 
 	node->value = value;
-	dclist_push_tail(&pstate->result_cache, &node->node);
+	dclist_push_tail(head, &node->node);
 }
+
+static double
+pop_result_from_cache(dclist_head *head)
+{
+	result_node *node = (result_node *) dclist_pop_head_node(head);
+
+	return node->value;
+}
+
+/* ------------------------ Result Cache Linked List End ------------------------ */
 
 
 static void
@@ -133,7 +115,7 @@ parse_result_to_cache(const NeurDBInferenceResult * result,
 
 				/* Convert to double */
 				/* printf("Found double: %f\n", value); */
-				insert_result_to_cache(pstate, value);
+				push_result_to_cache(&pstate->result_cache, value);
 
 				/* Reset buffer index */
 				bufIndex = 0;
@@ -158,50 +140,16 @@ parse_result_to_cache(const NeurDBInferenceResult * result,
 		double		value = atof(buffer);
 
 		/* printf("Found double: %f\n", value); */
-		insert_result_to_cache(pstate, value);
+		push_result_to_cache(&pstate->result_cache, value);
 	}
 }
 
-#if 0
-static void
-return_table(DestReceiver *dest, const NeurDBInferenceResult * result)
-{
-	TupOutputState *tstate;
-	TupleDesc	tupdesc;
-	ListCell   *lc;
-
-	if (result->typeoid == FLOAT8OID)
-	{
-		tupdesc = CreateTemplateTupleDesc(1);
-		TupleDescInitEntry(tupdesc, (AttrNumber) 1, "result", result->typeoid, -1, 0);
-
-		tstate = begin_tup_output_tupdesc(dest, tupdesc, &TTSOpsVirtual);
-
-		parse_result_to_cache(result, &insert_float8_to_tup_output, tstate, false);
-	}
-	else if (result->typeoid == TEXTOID)
-	{
-		tupdesc = CreateTemplateTupleDesc(2);
-		TupleDescInitEntry(tupdesc, (AttrNumber) 1, "result", result->typeoid, -1, 0);
-		TupleDescInitEntry(tupdesc, (AttrNumber) 2, "_dbg_value", FLOAT8OID, -1, 0);
-
-
-		tstate = begin_tup_output_tupdesc(dest, tupdesc, &TTSOpsVirtual);
-
-		parse_result_to_cache(result, &insert_cstring_to_tup_output, tstate, true);
-	}
-	else
-	{
-		elog(ERROR, "Unsupported data type");
-	}
-
-	end_tup_output(tstate);
-
-}
-#endif
 
 static char **
-get_column_names(const char *schema_name, const char *table_name, const char *exclude, int *num_included_out)
+get_column_names(const char *schema_name,
+				 const char *table_name,
+				 const char *exclude,
+				 int *num_included_out)
 {
 	int			max_num_columns = 100;
 
@@ -252,147 +200,16 @@ get_column_names(const char *schema_name, const char *table_name, const char *ex
 	return column_names;
 }
 
-
-typedef struct
-{
-	Datum		value;
-	bool		isnull;
-}			UdfResult;
-
-static UdfResult
-call_udf_function(const char *funcName,
-				  Oid *argTypes,
-				  int nargs,
-				  Datum *args,
-				  bool *nulls)
-{
-	FmgrInfo	fmgrInfo;
-
-	LOCAL_FCINFO(fcinfo, FUNC_MAX_ARGS);
-	Oid			funcOid;
-	UdfResult	result;
-
-	funcOid = LookupFuncName(list_make1(makeString(funcName)), nargs, argTypes, false);
-	if (!OidIsValid(funcOid))
-		elog(ERROR, "Function %s not found", funcName);
-
-	fmgr_info(funcOid, &fmgrInfo);
-	InitFunctionCallInfoData(*fcinfo, &fmgrInfo, nargs, InvalidOid, NULL, NULL);
-
-	for (int i = 0; i < nargs; i++)
-	{
-		fcinfo->args[i].value = args[i];
-		fcinfo->args[i].isnull = nulls ? nulls[i] : false;
-	}
-
-	result.value = FunctionCallInvoke(fcinfo);
-	result.isnull = fcinfo->isnull;
-
-	if (result.isnull)
-		elog(DEBUG2, "%s returned NULL", funcName);
-
-	return result;
-}
-
-#if 0
-/*
-* exec_udf --- Execute customer UDFs
-*
-* columns: columns names.
-* table: table used.
-* whereClause: where condition.
-*
-* @note: parameters in exec_udf are all hard-coded for now. In the future, we
-* will need to change this to adapt to the actual situation. This function
-* needs to be revamped to be more general.
-*/
-static void
-exec_udf(PredictType type,
-		 const char *model,
-		 const char *table,
-		 const char *trainColumns,
-		 const char *targetColumn,
-		 const char *whereClause,
-		 DestReceiver *dest)
-{
-	ArrayType  *trainColumnArray = get_train_columns_array(table, targetColumn, trainColumns);
-	int			modelId = 0;
-
-	/* model does not exist, training first */
-	if (modelId == 0)
-	{
-		Datum		args[TRAINING_PARAMS_ARRAY_SIZE];
-		bool		nulls[TRAINING_PARAMS_ARRAY_SIZE] = {false};
-
-		args[0] = CStringGetTextDatum(model);
-		args[1] = CStringGetTextDatum(table);
-		args[2] = Int32GetDatum(NrTaskBatchSize);
-		args[3] = Int32GetDatum(NrTaskNumBatches);
-		args[4] = Int32GetDatum(NrTaskEpoch);
-		args[5] = Int32GetDatum(NrTaskMaxFeatures);
-		args[6] = PointerGetDatum(trainColumnArray);
-		args[7] = CStringGetTextDatum(targetColumn);
-		args[8] = Int32GetDatum(type);
-
-		UdfResult	res = call_udf_function(trainingFuncName,
-											trainingArgTypes,
-											TRAINING_PARAMS_ARRAY_SIZE,
-											args, nulls);
-
-		if (!res.isnull)
-		{
-			int			result = DatumGetInt32(res.value);
-
-			elog(NOTICE, "Training result: %d", result);
-			modelId = result;
-		}
-		else
-		{
-			elog(NOTICE, "Training result is NULL");
-		}
-	}
-
-	/* inference */
-	ArrayType  *trainColumnArray = get_train_columns_array(table, targetColumn, trainColumns);
-	Datum		args[INFERENCE_PARAMS_ARRAY_SIZE];
-	bool		nulls[INFERENCE_PARAMS_ARRAY_SIZE] = {false};
-
-	args[0] = CStringGetTextDatum(model);
-	args[1] = Int32GetDatum(modelId);
-	args[2] = CStringGetTextDatum(table);
-	args[3] = Int32GetDatum(NrTaskBatchSize);
-	args[4] = Int32GetDatum(NrTaskEpoch);
-	args[5] = Int32GetDatum(NrTaskMaxFeatures);
-	args[6] = PointerGetDatum(trainColumnArray);
-	args[7] = CStringGetTextDatum(targetColumn);
-	args[8] = Int32GetDatum(type);
-
-	UdfResult	inferRes = call_udf_function(inferenceFuncName,
-											 inferenceArgTypes,
-											 INFERENCE_PARAMS_ARRAY_SIZE,
-											 args, nulls);
-
-	if (!inferRes.isnull)
-	{
-		NeurDBInferenceResult *result = (NeurDBInferenceResult *) DatumGetPointer(inferRes.value);
-
-		return_table(dest, result);
-	}
-	else
-	{
-		elog(DEBUG2, "Inference result is NULL");
-	}
-}
-#endif
-
-
 /**
  * Fill the given slot with one tuple derived from a NeurDBInferenceResult.
  * The slot already has a valid TupleDesc matching the node’s output schema.
  * Returns the same slot pointer.
  */
 static TupleTableSlot *
-build_result_slot(double value, bool is_float, List *id_class_map, TupleTableSlot *slot)
+build_result_slot(double value,
+				  bool is_float,
+				  List *id_class_map,
+				  TupleTableSlot *slot)
 {
 	ExecClearTuple(slot);
 
@@ -450,24 +267,6 @@ add_slot_to_cache(NeurDBPredictState * predictstate, TupleTableSlot *slot)
 	predictstate->slot_cache[predictstate->slot_cache_size++] = slot_copy;
 	ReleaseTupleDesc(slot->tts_tupleDescriptor);
 }
-
-static void
-_call_pipeline_close()
-{
-	/* tell nr_pipeline to close the connection */
-	elog(DEBUG1, "close connection");
-
-	Oid			funcOid = LookupFuncName(list_make1(makeString(closeFuncName)),
-										 CLOSE_PARAMS_ARRAY_SIZE,
-										 closeArgTypes,
-										 false);
-
-	if (!OidIsValid(funcOid))
-		elog(ERROR, "Function %s not found", stateChangeFuncName);
-
-	OidFunctionCall0(funcOid);
-}
-
 
 static TupleTableSlot *
 ExecNeurDBPredict(PlanState *pstate)
@@ -572,9 +371,9 @@ ExecNeurDBPredict(PlanState *pstate)
 						elog(DEBUG1, "change state to inference");
 
 						Oid			funcOid = LookupFuncName(list_make1(makeString(stateChangeFuncName)),
-															STATECHANGE_PARAMS_ARRAY_SIZE,
-															stateChangeArgTypes,
-															false);
+															 STATECHANGE_PARAMS_ARRAY_SIZE,
+															 stateChangeArgTypes,
+															 false);
 
 						if (!OidIsValid(funcOid))
 							elog(ERROR, "Function %s not found", stateChangeFuncName);
@@ -677,10 +476,10 @@ ExecNeurDBPredict(PlanState *pstate)
 					slot = ExecProject(predictstate->ps.ps_ProjInfo);
 
 					/* get the next result from the cache */
-					result_node *node = (result_node *) dclist_pop_head_node(&predictstate->result_cache);
+					double		value = pop_result_from_cache(&predictstate->result_cache);
 
 					/* build the returning slot */
-					build_result_slot(node->value, predictstate->is_float, predictstate->id_class_map, slot);
+					build_result_slot(value, predictstate->is_float, predictstate->id_class_map, slot);
 
 					predictstate->num_consumed += 1;
 					return slot;
@@ -698,9 +497,11 @@ ExecNeurDBPredict(PlanState *pstate)
 }
 
 static ArrayType *
-get_train_columns_array(const char *table, const char *targetColumn, const char *trainColumns)
+build_train_columns_array(const char *table,
+						  const char *targetColumns,
+						  const char *trainColumns)
 {
-	List	   *trainColumnsList = split_columns(trainColumns);
+	List	   *trainColumnsList = split_comma_c_string(trainColumns);
 	Datum	   *trainColumnDatums;
 	int			nTrainColumns = 0;
 
@@ -708,7 +509,7 @@ get_train_columns_array(const char *table, const char *targetColumn, const char 
 	{
 		/* all columns are used for training */
 		/* get all column names */
-		char	  **allColumns = get_column_names("public", table, targetColumn, &nTrainColumns);
+		char	  **allColumns = get_column_names("public", table, targetColumns, &nTrainColumns);
 
 		trainColumnDatums = (Datum *) palloc(sizeof(Datum) * nTrainColumns);
 		for (int i = 0; i < nTrainColumns; i++)
@@ -737,7 +538,7 @@ get_train_columns_array(const char *table, const char *targetColumn, const char 
 
 
 static StringInfoData
-construct_target_columns(List *targetList)
+build_target_columns(List *targetList)
 {
 	StringInfoData result;
 	ListCell   *cell;
@@ -870,14 +671,6 @@ ExecInitNeurDBPredict(NeurDBPredict * node, EState *estate, int eflags)
 	outerPlan = outerPlan(node);
 	outerPlanState(predictstate) = ExecInitNode(outerPlan, estate, eflags);
 
-#if 0
-
-	/*
-	 * Initialize result tuple slot
-	 */
-	ExecInitResultTupleSlotTL(&predictstate->ps, &TTSOpsVirtual);
-#endif
-
 	/*
 	 * Initialize result tuple slot with FIXED descriptor Need to determine
 	 * upfront if we're doing classification or regression
@@ -939,7 +732,7 @@ ExecInitNeurDBPredict(NeurDBPredict * node, EState *estate, int eflags)
 								(PlanState *) predictstate,
 								ExecTypeFromTL(node->predictTargetList));
 
-	StringInfoData targetColumn = construct_target_columns(node->predictTargetList);
+	StringInfoData targetColumns = build_target_columns(node->predictTargetList);
 
 	Datum		args[INIT_PARAMS_ARRAY_SIZE];
 	bool		nulls[INIT_PARAMS_ARRAY_SIZE] = {false};
@@ -948,7 +741,9 @@ ExecInitNeurDBPredict(NeurDBPredict * node, EState *estate, int eflags)
 	char	   *model = _temp_extract_model_name(predictstate->stmt->trainOnSpec);
 	StringInfoData trainOnColumns = _temp_extract_train_on_columns(node->trainOn);
 
-	ArrayType  *trainColumnArray = get_train_columns_array(table, targetColumn.data, trainOnColumns.data);
+	ArrayType  *trainColumnArray = build_train_columns_array(table,
+															 targetColumns.data,
+															 trainOnColumns.data);
 
 	args[0] = CStringGetTextDatum(model);
 	args[1] = CStringGetTextDatum(table);
@@ -957,7 +752,7 @@ ExecInitNeurDBPredict(NeurDBPredict * node, EState *estate, int eflags)
 	args[4] = Int32GetDatum(NrTaskNumBatches);
 	args[5] = Int32GetDatum(NrTaskMaxFeatures);
 	args[6] = PointerGetDatum(trainColumnArray);
-	args[7] = CStringGetTextDatum(targetColumn.data);
+	args[7] = CStringGetTextDatum(targetColumns.data);
 	args[8] = Int32GetDatum(predictstate->stmt->kind);
 	args[9] = PointerGetDatum(ExecTypeFromTL(outerPlan->targetlist));
 
@@ -991,6 +786,24 @@ ExecInitNeurDBPredict(NeurDBPredict * node, EState *estate, int eflags)
 	return predictstate;
 }
 
+
+static void
+call_pipeline_close()
+{
+	/* tell nr_pipeline to close the connection */
+	elog(DEBUG1, "close connection");
+
+	Oid			funcOid = LookupFuncName(list_make1(makeString(closeFuncName)),
+										 CLOSE_PARAMS_ARRAY_SIZE,
+										 closeArgTypes,
+										 false);
+
+	if (!OidIsValid(funcOid))
+		elog(ERROR, "Function %s not found", stateChangeFuncName);
+
+	OidFunctionCall0(funcOid);
+}
+
 /* ----------------------------------------------------------------
  *		ExecEndNeurDBPredict
  *
@@ -1003,7 +816,7 @@ ExecEndNeurDBPredict(NeurDBPredictState * node)
 {
 	ExecFreeExprContext(&node->ps);
 	ExecEndNode(outerPlanState(node));
-	_call_pipeline_close();
+	call_pipeline_close();
 	elog(DEBUG1, "NeurDB prediction end");
 }
 

--- a/dbengine/nr_kernel/nr_ext/src/nodePredict.c
+++ b/dbengine/nr_kernel/nr_ext/src/nodePredict.c
@@ -249,9 +249,25 @@ build_result_slot(double value,
 }
 
 static TupleTableSlot *
-expand_primary_key_to_tuple_slot(TupleTableSlot *slot, TupleDesc tupdesc)
+append_primary_values_to_tuple_slot(TupleTableSlot *proj_slot,
+									AttrNumber *primkeyindexes,
+									int nkeys,
+									TupleTableSlot *slot_copy,
+									int start_i)
 {
+	for (int i = 0; i < nkeys; i++)
+	{
+		Datum		value;
+		bool		isNull;
 
+		value = slot_copy->tts_values[primkeyindexes[i]];
+		isNull = slot_copy->tts_isnull[primkeyindexes[i]];
+
+		proj_slot->tts_values[start_i + i] = value;
+		proj_slot->tts_isnull[start_i + i] = isNull;
+	}
+
+	return proj_slot;
 }
 
 static void
@@ -478,6 +494,15 @@ ExecNeurDBPredict(PlanState *pstate)
 					/* get the next slot from the cache */
 					slot = predictstate->slot_cache[predictstate->num_consumed];
 
+					TupleTableSlot *slot_copy;
+
+					if (predictstate->stmt->withPrimaryKey)
+					{
+						/* copy the primary key to a new slot */
+						slot_copy = MakeTupleTableSlot(slot->tts_tupleDescriptor, &TTSOpsVirtual);
+						ExecCopySlot(slot_copy, slot);
+					}
+
 					/* project the slot */
 					predictstate->ps.ps_ExprContext->ecxt_outertuple = slot;
 					slot = ExecProject(predictstate->ps.ps_ProjInfo);
@@ -487,6 +512,17 @@ ExecNeurDBPredict(PlanState *pstate)
 
 					/* build the returning slot */
 					build_result_slot(value, predictstate->is_float, predictstate->id_class_map, slot);
+
+					if (predictstate->stmt->withPrimaryKey)
+					{
+						slot = append_primary_values_to_tuple_slot(slot,
+																   predictstate->primkeyindexes,
+																   predictstate->nkeys,
+																   slot_copy,
+																   predictstate->is_float ? 1 : 2);
+
+						ReleaseTupleDesc(slot_copy->tts_tupleDescriptor);
+					}
 
 					predictstate->num_consumed += 1;
 					return slot;
@@ -690,29 +726,9 @@ _append_primary_key_tuple_desc(TupleDesc resultDesc,
 	{
 		Form_pg_attribute attr;
 
-		attr = TupleDescAttr(tableDesc, keys[k] - 1);
+		attr = TupleDescAttr(tableDesc, keys[k]);
 
 		const char *name = NameStr(attr->attname);
-
-		/* check if the name is in the predict target list */
-		ListCell   *lc;
-		bool		skip = false;
-
-		foreach(lc, predictTargetList)
-		{
-			TargetEntry *tle = (TargetEntry *) lfirst(lc);
-
-			if (strcmp(name, tle->resname) == 0)
-			{
-				/* skip this attribute */
-				skip = true;
-				break;
-			}
-		}
-		if (skip)
-		{
-			continue;
-		}
 
 		TupleDescInitEntry(resultDesc,
 						   (AttrNumber) (start_i),
@@ -807,14 +823,44 @@ ExecInitNeurDBPredict(NeurDBPredict * node, EState *estate, int eflags)
 		{
 			/* no primary key, use full table */
 			TupleDesc	tableDesc;
+			Form_pg_attribute attr;
+			bool		skip;
 
 			tableDesc = RelationGetDescr(rel);
 
-			nkeys = tableDesc->natts;
+			nkeys = tableDesc->natts - natts;
 			keys = (AttrNumber *) palloc(sizeof(AttrNumber) * nkeys);
-			for (int i = 0; i < nkeys; i++)
+
+			i = 0;
+
+			for (int k = 0; k < tableDesc->natts; k++)
 			{
-				keys[i] = i + 1;
+				attr = TupleDescAttr(tableDesc, k);
+
+				const char *name = NameStr(attr->attname);
+
+				/* check if the name is in the predict target list */
+				ListCell   *lc;
+
+				skip = false;
+				foreach(lc, node->predictTargetList)
+				{
+					TargetEntry *tle = (TargetEntry *) lfirst(lc);
+
+					if (strcmp(name, tle->resname) == 0)
+					{
+						/* skip this attribute */
+						skip = true;
+						break;
+					}
+				}
+				if (skip)
+				{
+					continue;
+				}
+
+				keys[i] = k;
+				i++;
 			}
 		}
 	}
@@ -825,9 +871,7 @@ ExecInitNeurDBPredict(NeurDBPredict * node, EState *estate, int eflags)
 
 	if (add_primary_key)
 	{
-		int temp = natts;
 		natts += nkeys;
-		natts -= temp;
 	}
 
 	if (needsDebugColumn)
@@ -860,6 +904,9 @@ ExecInitNeurDBPredict(NeurDBPredict * node, EState *estate, int eflags)
 													keys,
 													node->predictTargetList,
 													i);
+
+		predictstate->primkeyindexes = keys;
+		predictstate->nkeys = nkeys;
 	}
 
 	relation_close(rel, AccessShareLock);

--- a/dbengine/nr_kernel/nr_ext/src/nodePredict.c
+++ b/dbengine/nr_kernel/nr_ext/src/nodePredict.c
@@ -814,7 +814,7 @@ ExecInitNeurDBPredict(NeurDBPredict * node, EState *estate, int eflags)
 					ereport(ERROR,
 							(errmsg("replica identity index contains expressions")));
 
-				keys[i] = idx->indkey.values[i];
+				keys[i] = idx->indkey.values[i] - 1;
 			}
 
 			index_close(idxrel, AccessShareLock);

--- a/dbengine/nr_kernel/nr_ext/src/nodePredict.c
+++ b/dbengine/nr_kernel/nr_ext/src/nodePredict.c
@@ -6,6 +6,7 @@
 #include "executor/spi.h"
 #include "nodes/execnodes.h"
 
+#include "access/genam.h"
 #include "access/relation.h"
 #include "access/heapam.h"
 #include "funcapi.h"
@@ -245,6 +246,12 @@ build_result_slot(double value,
 	ExecStoreVirtualTuple(slot);
 
 	return slot;
+}
+
+static TupleTableSlot *
+expand_primary_key_to_tuple_slot(TupleTableSlot *slot, TupleDesc tupdesc)
+{
+
 }
 
 static void
@@ -644,6 +651,83 @@ _temp_extract_table_name(List *fromClause)
 }
 
 
+static TupleDesc
+_copy_tuple_desc(List *targetList, TupleDesc resultDesc)
+{
+	int			i = 1;
+	ListCell   *lc;
+
+	foreach(lc, targetList)
+	{
+		TargetEntry *tle = (TargetEntry *) lfirst(lc);
+
+		TupleDescInitEntry(resultDesc,
+						   (AttrNumber) i,
+						   tle->resname,
+						   exprType((Node *) tle->expr),
+						   exprTypmod((Node *) tle->expr),
+						   0);
+		i++;
+	}
+
+	return resultDesc;
+}
+
+static TupleDesc
+_append_primary_key_tuple_desc(TupleDesc resultDesc,
+							   Relation rel,
+							   int nkeys,
+							   AttrNumber *keys,
+							   List *predictTargetList,
+							   int start_i)
+{
+	/* get tuple desc of the table */
+	TupleDesc	tableDesc;
+
+	tableDesc = RelationGetDescr(rel);
+
+	for (int k = 0; k < nkeys; k++)
+	{
+		Form_pg_attribute attr;
+
+		attr = TupleDescAttr(tableDesc, keys[k] - 1);
+
+		const char *name = NameStr(attr->attname);
+
+		/* check if the name is in the predict target list */
+		ListCell   *lc;
+		bool		skip = false;
+
+		foreach(lc, predictTargetList)
+		{
+			TargetEntry *tle = (TargetEntry *) lfirst(lc);
+
+			if (strcmp(name, tle->resname) == 0)
+			{
+				/* skip this attribute */
+				skip = true;
+				break;
+			}
+		}
+		if (skip)
+		{
+			continue;
+		}
+
+		TupleDescInitEntry(resultDesc,
+						   (AttrNumber) (start_i),
+						   name,
+						   attr->atttypid,
+						   attr->atttypmod,
+						   attr->attcollation);
+
+		start_i++;
+	}
+
+	return resultDesc;
+}
+
+
 NeurDBPredictState *
 ExecInitNeurDBPredict(NeurDBPredict * node, EState *estate, int eflags)
 {
@@ -678,44 +762,107 @@ ExecInitNeurDBPredict(NeurDBPredict * node, EState *estate, int eflags)
 	TupleDesc	resultDesc;
 	int			natts = list_length(node->predictTargetList);
 
+	char	   *table = _temp_extract_table_name(predictstate->stmt->fromClause);
+
+	bool		add_primary_key = node->stmt->withPrimaryKey;
+	bool		use_full = false;
+	int			nkeys = 0;
+	AttrNumber *keys = NULL;
+
+	int			i;
+
+	RangeVar   *rv = makeRangeVar(NULL, table, -1);
+	Oid			relid = RangeVarGetRelid(rv, NoLock, false);
+	Relation	rel = relation_open(relid, AccessShareLock);
+
+	if (add_primary_key)
+	{
+		Oid			ident_index;
+
+		ident_index = RelationGetReplicaIndex(rel);
+
+		if (OidIsValid(ident_index))
+		{
+			Relation	idxrel;
+			Form_pg_index idx;
+
+			idxrel = index_open(ident_index, AccessShareLock);
+			idx = idxrel->rd_index;
+
+			nkeys = idx->indnatts;
+			keys = (AttrNumber *) palloc(sizeof(AttrNumber) * nkeys);
+
+			for (i = 0; i < nkeys; i++)
+			{
+				if (idx->indkey.values[i] == 0)
+					ereport(ERROR,
+							(errmsg("replica identity index contains expressions")));
+
+				keys[i] = idx->indkey.values[i];
+			}
+
+			index_close(idxrel, AccessShareLock);
+		}
+		else
+		{
+			/* no primary key, use full table */
+			TupleDesc	tableDesc;
+
+			tableDesc = RelationGetDescr(rel);
+
+			nkeys = tableDesc->natts;
+			keys = (AttrNumber *) palloc(sizeof(AttrNumber) * nkeys);
+			for (int i = 0; i < nkeys; i++)
+			{
+				keys[i] = i + 1;
+			}
+		}
+	}
+
 	/* Determine if we need the debug column (for classification) */
 	/* You may need to determine this from node->stmt->kind or other metadata */
 	bool		needsDebugColumn = (node->stmt->kind == PREDICT_CLASS);
 
+	if (add_primary_key)
+	{
+		int temp = natts;
+		natts += nkeys;
+		natts -= temp;
+	}
+
 	if (needsDebugColumn)
 	{
-		/* Classification: add debug column */
-		resultDesc = CreateTemplateTupleDesc(natts + 1);
+		natts++;
+	}
 
-		int			i = 1;
-		ListCell   *lc;
+	resultDesc = CreateTemplateTupleDesc(natts);
+	resultDesc = _copy_tuple_desc(node->predictTargetList, resultDesc);
 
-		foreach(lc, node->predictTargetList)
-		{
-			TargetEntry *tle = (TargetEntry *) lfirst(lc);
+	i = list_length(node->predictTargetList) + 1;
 
-			TupleDescInitEntry(resultDesc,
-							   (AttrNumber) i,
-							   tle->resname,
-							   exprType((Node *) tle->expr),
-							   exprTypmod((Node *) tle->expr),
-							   0);
-			i++;
-		}
-
+	if (needsDebugColumn)
+	{
 		/* Add debug column */
 		TupleDescInitEntry(resultDesc,
-						   (AttrNumber) (natts + 1),
+						   (AttrNumber) (i),
 						   "_dbg_value",
 						   FLOAT8OID,
 						   -1,
 						   0);
+		i++;
 	}
-	else
+
+	if (add_primary_key)
 	{
-		/* Regression: no debug column */
-		resultDesc = ExecTypeFromTL(node->predictTargetList);
+		resultDesc = _append_primary_key_tuple_desc(resultDesc,
+													rel,
+													nkeys,
+													keys,
+													node->predictTargetList,
+													i);
 	}
+
+	relation_close(rel, AccessShareLock);
 
 	resultDesc = BlessTupleDesc(resultDesc);
 	ExecInitResultTupleSlotTL(&predictstate->ps, &TTSOpsVirtual);
@@ -737,7 +884,6 @@ ExecInitNeurDBPredict(NeurDBPredict * node, EState *estate, int eflags)
 	Datum		args[INIT_PARAMS_ARRAY_SIZE];
 	bool		nulls[INIT_PARAMS_ARRAY_SIZE] = {false};
 
-	char	   *table = _temp_extract_table_name(predictstate->stmt->fromClause);
 	char	   *model = _temp_extract_model_name(predictstate->stmt->trainOnSpec);
 	StringInfoData trainOnColumns = _temp_extract_train_on_columns(node->trainOn);
 

--- a/dbengine/nr_kernel/nr_ext/src/util.h
+++ b/dbengine/nr_kernel/nr_ext/src/util.h
@@ -1,0 +1,63 @@
+#ifndef UTIL_H
+#define UTIL_H
+
+#include "nodes/pg_list.h"
+#include "nodes/value.h"
+
+List *
+split_comma_c_string(char *value)
+{
+	List	   *result = NIL;
+	char	   *token = strtok(value, ",");
+
+	while (token != NULL)
+	{
+		result = lappend(result, makeString(token));
+		token = strtok(NULL, ",");
+	}
+	return result;
+}
+
+/* ------------------------ UDF ---------------------------- */
+
+typedef struct
+{
+	Datum		value;
+	bool		isnull;
+}			UdfResult;
+
+static UdfResult call_udf_function(const char *funcName, Oid *argTypes,
+								   int nargs, Datum *args, bool *nulls)
+{
+	FmgrInfo	fmgrInfo;
+
+	LOCAL_FCINFO(fcinfo, FUNC_MAX_ARGS);
+	Oid			funcOid;
+	UdfResult	result;
+
+	funcOid = LookupFuncName(list_make1(makeString(funcName)), nargs, argTypes,
+							 false);
+	if (!OidIsValid(funcOid))
+		elog(ERROR, "Function %s not found", funcName);
+
+	fmgr_info(funcOid, &fmgrInfo);
+	InitFunctionCallInfoData(*fcinfo, &fmgrInfo, nargs, InvalidOid, NULL, NULL);
+
+	for (int i = 0; i < nargs; i++)
+	{
+		fcinfo->args[i].value = args[i];
+		fcinfo->args[i].isnull = nulls ? nulls[i] : false;
+	}
+
+	result.value = FunctionCallInvoke(fcinfo);
+	result.isnull = fcinfo->isnull;
+
+	if (result.isnull)
+		elog(DEBUG2, "%s returned NULL", funcName);
+
+	return result;
+}
+
+/* ------------------------ UDF end ------------------------ */
+
+#endif

--- a/dbengine/nr_kernel/nr_pipeline/src/interface2.c
+++ b/dbengine/nr_kernel/nr_pipeline/src/interface2.c
@@ -9,6 +9,10 @@
  */
 #include "interface2.h"
 
+#include <access/relation.h>
+#include <access/genam.h>
+#include <catalog/namespace.h>
+#include <nodes/makefuncs.h>
 #include <utils/builtins.h>
 #include <utils/array.h>
 #include <utils/hsearch.h>
@@ -133,6 +137,45 @@ static char *char_array2str(char **char_array, int n_elements) {
     return str.data;
 }
 
+
+static List *
+get_primary_key_ids(const char *table_name) {
+	RangeVar   *rv = makeRangeVar(NULL, table_name, -1);
+	Oid			relid = RangeVarGetRelid(rv, NoLock, false);
+	Relation	rel = relation_open(relid, AccessShareLock);
+
+    Oid			ident_index;
+
+    List *keys = NIL;
+
+    ident_index = RelationGetReplicaIndex(rel);
+
+    if (OidIsValid(ident_index))
+    {
+        Relation	idxrel;
+        Form_pg_index idx;
+
+        idxrel = index_open(ident_index, AccessShareLock);
+        idx = idxrel->rd_index;
+
+        for (int i = 0; i < idx->indnatts; i++)
+        {
+            if (idx->indkey.values[i] == 0)
+                ereport(ERROR,
+                        (errmsg("replica identity index contains expressions")));
+
+            keys = lappend_int(keys, i);
+        }
+
+        index_close(idxrel, AccessShareLock);
+    }
+
+    relation_close(rel, AccessShareLock);
+
+    return keys;
+}
+
+
 static void build_libsvm_data(
     SPITupleTable *tuptable,
     TupleDesc tupdesc,
@@ -142,7 +185,8 @@ static void build_libsvm_data(
     StringInfo libsvm_data,
     bool has_label,
     int label_col,
-    const char *model_name
+    const char *model_name,
+    List *primary_key_ids
 ) {
     StringInfoData row_data;
     initStringInfo(&row_data);
@@ -172,6 +216,13 @@ static void build_libsvm_data(
                 col + 1,
                 &is_null
             );
+
+            /* col because of the first column is the label */
+            if (list_member_int(primary_key_ids, col)) {
+                // skip primary key
+                continue;
+            }
+            
             int type = SPI_gettypeid(tupdesc, col + 1);
             switch (type) {
                 case INT2OID:
@@ -354,7 +405,8 @@ run_infer_batch(PipelineSession *session, bool flush) {
         &libsvm,
         false,
         0,
-        session->model_name
+        session->model_name,
+        session->primary_key_ids
     );
     nws_send_batch_data(ws, 0, S_INFERENCE, libsvm.data);
     nws_wait_completion(ws);
@@ -411,7 +463,8 @@ run_train_batch(PipelineSession *session, bool flush) {
         &libsvm,
         true,
         session->label_col_id,
-        session->model_name
+        session->model_name,
+        session->primary_key_ids
     );
 
     nws_send_batch_data(session->ws, 0, S_TRAIN, libsvm.data);
@@ -459,6 +512,7 @@ pipeline_init(
     if (PIPELINE_SESSION.label_col_id < 0) {
         elog(ERROR, "label column %s not found", target);
     }
+    PIPELINE_SESSION.primary_key_ids = get_primary_key_ids(table_name);
 
     // look up for existing model
     int model_id = _lookup_model(PIPELINE_SESSION.table_name, PIPELINE_SESSION.feature_names,

--- a/dbengine/nr_kernel/nr_pipeline/src/interface2.c
+++ b/dbengine/nr_kernel/nr_pipeline/src/interface2.c
@@ -222,7 +222,7 @@ static void build_libsvm_data(
                 // skip primary key
                 continue;
             }
-            
+
             int type = SPI_gettypeid(tupdesc, col + 1);
             switch (type) {
                 case INT2OID:

--- a/dbengine/nr_kernel/nr_pipeline/src/interface2.h
+++ b/dbengine/nr_kernel/nr_pipeline/src/interface2.h
@@ -54,6 +54,8 @@ typedef struct {
     MemoryContext hash_ctx;
     HTAB *class_id_map;
     List *id_class_map;
+
+    List *primary_key_ids;
 } PipelineSession;
 
 

--- a/dbengine/src/backend/parser/gram.y
+++ b/dbengine/src/backend/parser/gram.y
@@ -665,7 +665,7 @@ static Node *makeRecursiveViewSelect(char *relname, List *aliases, Node *query);
 %type <list> 	neurdb_train_on_columns neurdb_train_on_list neurdb_from_list
 %type <target>	neurdb_train_on_el
 %type <str>		opt_neurdb_model_name
-/* %type <boolean> opt_allow_train */
+%type <boolean> opt_with_primary_key
 
 /*
  * Non-keyword token types.  These are hard-wired into the "flex" lexer.
@@ -16949,27 +16949,25 @@ NeurDBPredictStmt:
 		;
 
 neurdb_target: target_list
+			opt_with_primary_key
 			neurdb_from
-			/*opt_allow_train*/
 			opt_neurdb_train_on
 			opt_neurdb_values
 				{
-					NeurDBPredictStmt *n = (NeurDBPredictStmt *) $2;
+					NeurDBPredictStmt *n = (NeurDBPredictStmt *) $3;
 					n->targetList = $1;
-					/*n->allowTrain = $3;*/
-					n->trainOnSpec = (NeurDBTrainOnSpec *) $3;
-					n->values = (SelectStmt *) $4;
+					n->withPrimaryKey = $2;
+					n->trainOnSpec = (NeurDBTrainOnSpec *) $4;
+					n->values = (SelectStmt *) $5;
 					$$ = (Node *) n;
 				}
 		;
 
-
-/*
-opt_allow_train:
-			TRAIN IF_P NOT EXISTS					{ $$ = true; }
-			|  										{ $$ = false; }
+opt_with_primary_key:
+			WITH PRIMARY KEY					    { $$ = true; }
+			| 										{ $$ = false; }
 		;
-*/
+
 
 neurdb_from:
 		FROM relation_expr

--- a/dbengine/src/include/nodes/execnodes.h
+++ b/dbengine/src/include/nodes/execnodes.h
@@ -2778,21 +2778,23 @@ typedef enum
 	NEURDBPREDICT_INFERENCE_SEND,
 	NEURDBPREDICT_INFERENCE_RETURN,
 	NEURDBPREDICT_INFERENCE_END,
-} NeurDBPredictStateCond;
+}			NeurDBPredictStateCond;
 
 typedef struct NeurDBPredictState
 {
-	PlanState ps;						/* its first field is NodeTag */
+	PlanState	ps;				/* its first field is NodeTag */
 	NeurDBPredictStmt *stmt;
 	NeurDBPredictStateCond nrpstate;
 	TupleTableSlot **slot_cache;	/* result cache */
-	int	slot_cache_size;	/* result cache size */
-	bool is_final;
-	int num_consumed;
-	dclist_head	result_cache;
-	List *id_class_map;
-	bool is_float;
-	int curr_epoch;
-} NeurDBPredictState;
+	int			slot_cache_size;	/* result cache size */
+	bool		is_final;
+	int			num_consumed;
+	dclist_head result_cache;
+	List	   *id_class_map;
+	bool		is_float;
+	int			curr_epoch;
+	AttrNumber *primkeyindexes;
+	int			nkeys;
+}			NeurDBPredictState;
 
 #endif							/* EXECNODES_H */

--- a/dbengine/src/include/nodes/parsenodes.h
+++ b/dbengine/src/include/nodes/parsenodes.h
@@ -4081,6 +4081,7 @@ typedef struct NeurDBPredictStmt
 								 * prediction) */
 	List	   *targetList;		/* A list of targets (columns) for the
 								 * prediction */
+	bool        withPrimaryKey;  /* Whether the result includes primary key */
 	List	   *fromClause;		/* A list of tables involved in the prediction */
 	NeurDBTrainOnSpec *trainOnSpec; /* Sepc for the TRAIN ON syntax */
 	SelectStmt *values;			/* Values (following definition of


### PR DESCRIPTION
## Summary

This PR implements `WITH PRIMARY KEY` to `PREDICT` clauses. This allows users to locate specific row (and potentially combine it with other information).

The full grammar is:

```sql
PREDICT VALUE/CLASS OF column [WITH PRIMARY KEY] FROM ...
```

Regarding whether a table contains primary keys or not, it will perform differently (details below).

## Examples

### With primary keys

When a table contains primary key, such as `SELECT * FROM frappe_test_pk`:

```sql
  id  | click_rate | feature1 | feature2 | feature3 | feature4 | feature5 | feature6 | feature7 | feature8 | feature9 | feature10
------+------------+----------+----------+----------+----------+----------+----------+----------+----------+----------+-----------
    1 |          1 |      232 |     1193 |     5043 |     5052 |     5054 |     5055 |     5058 |     5061 |     5069 |      5185
    2 |          0 |      293 |     2046 |     5040 |     5048 |     5054 |     5055 |     5058 |     5060 |     5069 |      5158
    3 |          0 |        8 |     4122 |     5039 |     5049 |     5054 |     5055 |     5058 |     5064 |     5073 |      5183
    4 |          0 |      435 |     4715 |     5043 |     5051 |     5054 |     5056 |     5058 |     5061 |     5069 |      5149
    5 |          0 |       87 |     4421 |     5041 |     5050 |     5054 |     5055 |     5058 |     5060 |     5069 |      5151
    6 |          1 |       50 |      973 |     5043 |     5048 |     5054 |     5055 |     5058 |     5061 |     5077 |      5155
    7 |          0 |      423 |     2760 |     5041 |     5052 |     5053 |     5055 |     5058 |     5060 |     5087 |      5222
    8 |          0 |      409 |     2731 |     5041 |     5049 |     5054 |     5055 |     5058 |     5060 |     5080 |      5174
    9 |          0 |      234 |     1300 |     5040 |     5046 |     5053 |     5055 |     5058 |     5061 |     5069 |      5240
   10 |          1 |      108 |      978 |     5040 |     5049 |     5054 |     5056 |     5058 |     5065 |     5088 |      5190
```

When running `PREDICT VALUE OF click_rate WITH PRIMARY KEY FROM (SELECT * FROM frappe_test_pk) TRAIN ON *`, the result looks like:

```sql
     click_rate      |  id
---------------------+------
   7.626444339752197 |    1
  -7.106481075286865 |    2
  -6.912569046020508 |    3
  -6.873053073883057 |    4
  -7.029304027557373 |    5
   7.779529571533203 |    6
  -6.863740921020508 |    7
  -6.945136070251465 |    8
  -6.918369770050049 |    9
   7.881051540374756 |   10
```

Where `id` is attached to the right of the predicted column.

### Without primary keys

When a table does not contain primary key, such as `SELECT * FROM frappe_test`:

```sql
 click_rate | feature1 | feature2 | feature3 | feature4 | feature5 | feature6 | feature7 | feature8 | feature9 | feature10
------------+----------+----------+----------+----------+----------+----------+----------+----------+----------+-----------
          1 |      232 |     1193 |     5043 |     5052 |     5054 |     5055 |     5058 |     5061 |     5069 |      5185
          0 |      293 |     2046 |     5040 |     5048 |     5054 |     5055 |     5058 |     5060 |     5069 |      5158
          0 |        8 |     4122 |     5039 |     5049 |     5054 |     5055 |     5058 |     5064 |     5073 |      5183
          0 |      435 |     4715 |     5043 |     5051 |     5054 |     5056 |     5058 |     5061 |     5069 |      5149
          0 |       87 |     4421 |     5041 |     5050 |     5054 |     5055 |     5058 |     5060 |     5069 |      5151
          1 |       50 |      973 |     5043 |     5048 |     5054 |     5055 |     5058 |     5061 |     5077 |      5155
          0 |      423 |     2760 |     5041 |     5052 |     5053 |     5055 |     5058 |     5060 |     5087 |      5222
          0 |      409 |     2731 |     5041 |     5049 |     5054 |     5055 |     5058 |     5060 |     5080 |      5174
          0 |      234 |     1300 |     5040 |     5046 |     5053 |     5055 |     5058 |     5061 |     5069 |      5240
          1 |      108 |      978 |     5040 |     5049 |     5054 |     5056 |     5058 |     5065 |     5088 |      5190
```

When running `PREDICT VALUE OF click_rate WITH PRIMARY KEY FROM (SELECT * FROM frappe_test) TRAIN ON *`, the result looks like:

```sql
     click_rate      | feature1 | feature2 | feature3 | feature4 | feature5 | feature6 | feature7 | feature8 | feature9 | feature10
---------------------+----------+----------+----------+----------+----------+----------+----------+----------+----------+-----------
   7.866647243499756 |      232 |     1193 |     5043 |     5052 |     5054 |     5055 |     5058 |     5061 |     5069 |      5185
  -7.223214626312256 |      293 |     2046 |     5040 |     5048 |     5054 |     5055 |     5058 |     5060 |     5069 |      5158
   -7.19351863861084 |        8 |     4122 |     5039 |     5049 |     5054 |     5055 |     5058 |     5064 |     5073 |      5183
 -7.1201066970825195 |      435 |     4715 |     5043 |     5051 |     5054 |     5056 |     5058 |     5061 |     5069 |      5149
  -7.140254497528076 |       87 |     4421 |     5041 |     5050 |     5054 |     5055 |     5058 |     5060 |     5069 |      5151
   8.082738876342773 |       50 |      973 |     5043 |     5048 |     5054 |     5055 |     5058 |     5061 |     5077 |      5155
  -7.121787071228027 |      423 |     2760 |     5041 |     5052 |     5053 |     5055 |     5058 |     5060 |     5087 |      5222
 -7.1890153884887695 |      409 |     2731 |     5041 |     5049 |     5054 |     5055 |     5058 |     5060 |     5080 |      5174
  -7.225630760192871 |      234 |     1300 |     5040 |     5046 |     5053 |     5055 |     5058 |     5061 |     5069 |      5240
   7.729269504547119 |      108 |      978 |     5040 |     5049 |     5054 |     5056 |     5058 |     5065 |     5088 |      5190
```

Where all columns in the table are attached to differentiate each row.
