### PR TITLE
Add scripts for Docker release-mode build, native installation on Linux, Windows, and CI/CD workflows

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+build/
+.git/
+plans/
+doc/
+*.log
+*.md
+!requirements*.txt

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -1,0 +1,97 @@
+name: Build native Linux tarball
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-native:
+    name: Build native ${{ matrix.arch }} tarball
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        arch: [x86_64]
+
+    env:
+      INSTALL_PREFIX: /tmp/neurdb-dist/neurdb-${{ github.ref_name }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install system build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential flex bison \
+            libreadline-dev zlib1g-dev libicu-dev libssl-dev \
+            cmake pkg-config \
+            librocksdb-dev libwebsockets-dev libcjson-dev \
+            libcurl4-openssl-dev libpqxx-dev libopencv-dev \
+            git rsync \
+            python3 python3-pip python3-dev python3-venv
+
+      - name: Compile PostgreSQL
+        run: |
+          mkdir -p /tmp/pg-build && cd /tmp/pg-build
+          ${{ github.workspace }}/dbengine/configure --prefix=${{ env.INSTALL_PREFIX }}
+          make -j$(nproc)
+          make install
+
+      - name: Compile pg_hint_plan
+        run: |
+          git clone --depth=1 -b PG16 \
+            https://github.com/ossc-db/pg_hint_plan.git /tmp/pg_hint_plan
+          make -C /tmp/pg_hint_plan PG_CONFIG=${{ env.INSTALL_PREFIX }}/bin/pg_config
+          make -C /tmp/pg_hint_plan PG_CONFIG=${{ env.INSTALL_PREFIX }}/bin/pg_config install
+
+      - name: Compile nr_kernel extensions
+        run: |
+          cd dbengine/nr_kernel
+          make PG_CONFIG=${{ env.INSTALL_PREFIX }}/bin/pg_config
+          make PG_CONFIG=${{ env.INSTALL_PREFIX }}/bin/pg_config install
+
+      - name: Install Python AI runtime into virtualenv
+        run: |
+          python3 -m venv ${{ env.INSTALL_PREFIX }}/aiengine/venv
+          ${{ env.INSTALL_PREFIX }}/aiengine/venv/bin/pip install --no-cache-dir \
+            -r aiengine/runtime/requirements.cpu.txt \
+            --extra-index-url https://download.pytorch.org/whl/cpu
+
+      - name: Copy AI runtime source
+        run: |
+          cp -r aiengine/runtime ${{ env.INSTALL_PREFIX }}/aiengine/runtime
+
+      - name: Copy installer files
+        run: |
+          mkdir -p ${{ env.INSTALL_PREFIX }}/installer
+          cp installer/linux/install.sh ${{ env.INSTALL_PREFIX }}/installer/
+          cp installer/linux/uninstall.sh ${{ env.INSTALL_PREFIX }}/installer/
+          cp installer/linux/neurdb-db.service ${{ env.INSTALL_PREFIX }}/installer/
+          cp installer/linux/neurdb-ai.service ${{ env.INSTALL_PREFIX }}/installer/
+
+      - name: Strip version prefix from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Create tarball
+        run: |
+          cd /tmp/neurdb-dist
+          tar -czf neurdb-${{ steps.version.outputs.version }}-linux-${{ matrix.arch }}.tar.gz \
+            neurdb-${{ github.ref_name }}/
+
+      - name: Generate SHA256SUMS
+        run: |
+          cd /tmp/neurdb-dist
+          sha256sum neurdb-${{ steps.version.outputs.version }}-linux-${{ matrix.arch }}.tar.gz \
+            > SHA256SUMS
+
+      - name: Upload artifacts to GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cd /tmp/neurdb-dist
+          gh release upload "${{ github.ref_name }}" \
+            neurdb-${{ steps.version.outputs.version }}-linux-${{ matrix.arch }}.tar.gz \
+            SHA256SUMS \
+            --repo "${{ github.repository }}"

--- a/.github/workflows/docker-build-dev.yml
+++ b/.github/workflows/docker-build-dev.yml
@@ -13,7 +13,7 @@ on:
 
 env:
   DOCKER_IMAGE_NAME: neurdb-dev
-  RELEASE_VERSION: 0.2.0
+  RELEASE_VERSION: dev-${{ github.sha }}
 
 jobs:
   build_and_run_dev_docker_cpu:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,56 @@
+name: Publish Docker release images
+
+on:
+  release:
+    types: [published]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/neurdb
+
+jobs:
+  build-and-push:
+    name: Build and push ${{ matrix.variant }} image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        variant: [cpu, cuda11]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}},suffix=-${{ matrix.variant }}
+            type=raw,value=latest-${{ matrix.variant }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.release
+          target: release
+          build-args: VARIANT=${{ matrix.variant }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,46 @@
+name: Publish Python package to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    name: Build and publish to PyPI
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write  # Required for Trusted Publisher
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Verify VERSION matches release tag
+        working-directory: api/python
+        run: |
+          FILE_VERSION=$(cat VERSION | tr -d '[:space:]')
+          # Strip leading 'v' from tag if present (e.g. v0.2.0 -> 0.2.0)
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          if [ "$FILE_VERSION" != "$TAG_VERSION" ]; then
+            echo "ERROR: api/python/VERSION ($FILE_VERSION) does not match release tag ($TAG_VERSION)"
+            exit 1
+          fi
+          echo "Version check passed: $FILE_VERSION"
+
+      - name: Install build tools
+        run: pip install build
+
+      - name: Build package
+        working-directory: api/python
+        run: python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: api/python/dist/

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .idea/
 
 ### compiled output
+psql
 /psql/
 
 ### VS Code

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -96,7 +96,7 @@ USER root
 
 # Set environment variables for both root and other users
 ENV PKG_CONFIG_PATH="/usr/lib/x86_64-linux-gnu/pkgconfig"
-ENV LD_LIBRARY_PATH="/usr/lib/x86_64-linux-gnu:${LD_LIBRARY_PATH:-}"
+ENV LD_LIBRARY_PATH="/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH"
 ENV NEURDBPATH="/code/neurdb-dev"
 
 # Set the working directory

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -91,7 +91,7 @@ USER root
 
 # Set environment variables for both root and other users
 ENV PKG_CONFIG_PATH="/usr/lib/x86_64-linux-gnu/pkgconfig"
-ENV LD_LIBRARY_PATH="/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH"
+ENV LD_LIBRARY_PATH="/usr/lib/x86_64-linux-gnu:${LD_LIBRARY_PATH:-}"
 ENV NEURDBPATH="/code/neurdb-dev"
 
 # Set the working directory

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -7,6 +7,10 @@ EXPOSE 5432
 # Set environment variables to avoid interactive prompts during package installation
 ENV DEBIAN_FRONTEND=noninteractive
 
+# Accept the host user's UID/GID so file ownership on bind-mounts matches
+ARG HOST_UID=1000
+ARG HOST_GID=1000
+
 # Upgrade pip
 RUN apt-get update
 
@@ -68,7 +72,8 @@ RUN apt-get install -y \
 RUN echo "root:rootpassword" | chpasswd
 
 # Create a non-root user 'neurdb' with an empty password and add to sudoers
-RUN useradd -m -s /bin/bash neurdb && \
+RUN groupadd -g ${HOST_GID} neurdb || true && \
+    useradd -m -s /bin/bash -u ${HOST_UID} -g ${HOST_GID} neurdb && \
     passwd -d neurdb && \
     echo "neurdb ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 

--- a/Dockerfile.cuda11
+++ b/Dockerfile.cuda11
@@ -96,7 +96,7 @@ USER root
 
 # Set environment variables for both root and other users
 ENV PKG_CONFIG_PATH="/usr/lib/x86_64-linux-gnu/pkgconfig"
-ENV LD_LIBRARY_PATH="/usr/lib/x86_64-linux-gnu:${LD_LIBRARY_PATH:-}"
+ENV LD_LIBRARY_PATH="/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH"
 ENV NEURDBPATH="/code/neurdb-dev"
 
 # Set the working directory

--- a/Dockerfile.cuda11
+++ b/Dockerfile.cuda11
@@ -91,7 +91,7 @@ USER root
 
 # Set environment variables for both root and other users
 ENV PKG_CONFIG_PATH="/usr/lib/x86_64-linux-gnu/pkgconfig"
-ENV LD_LIBRARY_PATH="/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH"
+ENV LD_LIBRARY_PATH="/usr/lib/x86_64-linux-gnu:${LD_LIBRARY_PATH:-}"
 ENV NEURDBPATH="/code/neurdb-dev"
 
 # Set the working directory

--- a/Dockerfile.cuda11
+++ b/Dockerfile.cuda11
@@ -7,6 +7,10 @@ EXPOSE 5432
 # Set environment variables to avoid interactive prompts during package installation
 ENV DEBIAN_FRONTEND=noninteractive
 
+# Accept the host user's UID/GID so file ownership on bind-mounts matches
+ARG HOST_UID=1000
+ARG HOST_GID=1000
+
 # Upgrade pip
 RUN apt-get update
 
@@ -68,7 +72,8 @@ RUN apt-get install -y \
 RUN echo "root:rootpassword" | chpasswd
 
 # Create a non-root user 'neurdb' with an empty password and add to sudoers
-RUN useradd -m -s /bin/bash neurdb && \
+RUN groupadd -g ${HOST_GID} neurdb || true && \
+    useradd -m -s /bin/bash -u ${HOST_UID} -g ${HOST_GID} neurdb && \
     passwd -d neurdb && \
     echo "neurdb ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -15,8 +15,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     cmake pkg-config \
     librocksdb-dev libwebsockets-dev libcjson-dev \
     libcurl4-openssl-dev libpqxx-dev libopencv-dev \
-    # Source fetch (pg_hint_plan) and Makefile sync
-    git rsync \
+    # Source fetch (pg_hint_plan, protobuf, tokenizers-cpp) and Makefile sync
+    git rsync curl wget \
     # Python venv creation
     python3 python3-pip python3-dev python3-venv \
     && rm -rf /var/lib/apt/lists/*
@@ -35,6 +35,9 @@ RUN git clone --depth=1 -b PG16 \
     make -C /tmp/pg_hint_plan PG_CONFIG=/opt/neurdb/bin/pg_config install
 
 # 3. Compile nr_kernel extensions
+# Install Rust (needed by nr_store to build neurstore_core)
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
+ENV PATH="/root/.cargo/bin:${PATH}"
 RUN cd /src/dbengine/nr_kernel && \
     make PG_CONFIG=/opt/neurdb/bin/pg_config && \
     make PG_CONFIG=/opt/neurdb/bin/pg_config install
@@ -89,8 +92,11 @@ ENV LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8
 COPY --from=builder /opt/neurdb      /opt/neurdb
 COPY --from=builder /opt/neurdb-venv /opt/neurdb-venv
 
-# Create neurdb user, lock root account
-RUN useradd -m -s /bin/bash neurdb && passwd -l root
+# Create neurdb user, lock root account, and pre-create the data directory
+# with correct ownership so the container starts correctly as a non-root user.
+RUN useradd -m -s /bin/bash neurdb && passwd -l root && \
+    mkdir -p /var/lib/neurdb/data /var/log/neurdb && \
+    chown -R neurdb:neurdb /var/lib/neurdb /var/log/neurdb
 
 # Set environment variables for the neurdb user
 ENV PATH="/opt/neurdb/bin:/opt/neurdb-venv/bin:${PATH}"

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,0 +1,101 @@
+# Global build argument — selects cpu or cuda11 variant
+ARG VARIANT=cpu
+
+###############################################################################
+# Stage 1: builder — compiles PostgreSQL, extensions, and Python venv
+###############################################################################
+FROM ubuntu:22.04 AS builder
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    # PostgreSQL build requirements
+    build-essential flex bison \
+    libreadline-dev zlib1g-dev libicu-dev libssl-dev \
+    # nr_kernel extension build requirements
+    cmake pkg-config \
+    librocksdb-dev libwebsockets-dev libcjson-dev \
+    libcurl4-openssl-dev libpqxx-dev libopencv-dev \
+    # Source fetch (pg_hint_plan) and Makefile sync
+    git rsync \
+    # Python venv creation
+    python3 python3-pip python3-dev python3-venv \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY . /src
+
+# 1. Compile PostgreSQL (no --enable-debug for release)
+RUN mkdir -p /tmp/pg-build && cd /tmp/pg-build && \
+    /src/dbengine/configure --prefix=/opt/neurdb && \
+    make -j$(nproc) && make install
+
+# 2. Clone and build pg_hint_plan (shallow clone)
+RUN git clone --depth=1 -b PG16 \
+        https://github.com/ossc-db/pg_hint_plan.git /tmp/pg_hint_plan && \
+    make -C /tmp/pg_hint_plan PG_CONFIG=/opt/neurdb/bin/pg_config && \
+    make -C /tmp/pg_hint_plan PG_CONFIG=/opt/neurdb/bin/pg_config install
+
+# 3. Compile nr_kernel extensions
+RUN cd /src/dbengine/nr_kernel && \
+    make PG_CONFIG=/opt/neurdb/bin/pg_config && \
+    make PG_CONFIG=/opt/neurdb/bin/pg_config install
+
+# 4. Install Python AI runtime into an isolated virtualenv
+ARG VARIANT
+RUN python3 -m venv /opt/neurdb-venv && \
+    if [ "$VARIANT" = "cpu" ]; then \
+        /opt/neurdb-venv/bin/pip install --no-cache-dir \
+            -r /src/aiengine/runtime/requirements.cpu.txt \
+            --extra-index-url https://download.pytorch.org/whl/cpu; \
+    else \
+        /opt/neurdb-venv/bin/pip install --no-cache-dir \
+            -r /src/aiengine/runtime/requirements.txt \
+            --extra-index-url https://download.pytorch.org/whl/cu116; \
+    fi
+
+# 5. Copy AI runtime source into the venv directory
+RUN cp -r /src/aiengine/runtime /opt/neurdb-venv/runtime
+
+# 6. Copy the release entrypoint script
+RUN cp /src/docker-start.sh /opt/neurdb/bin/docker-start.sh && \
+    chmod +x /opt/neurdb/bin/docker-start.sh
+
+###############################################################################
+# Stage 2a/2b: Runtime base images
+###############################################################################
+FROM ubuntu:22.04 AS base-cpu
+
+FROM nvidia/cuda:11.8.0-runtime-ubuntu22.04 AS base-cuda11
+
+###############################################################################
+# Stage 3: release — runtime-only image
+###############################################################################
+ARG VARIANT
+FROM base-${VARIANT} AS release
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Runtime libraries only — no compilers, no -dev headers
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    librocksdb6.11 libwebsockets16 libcjson1 \
+    libreadline8 libicu70 zlib1g libssl3 \
+    libopencv-core4.5d \
+    python3 curl \
+    locales \
+    && locale-gen en_US.UTF-8 \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8
+
+# Copy only compiled artifacts from builder — no source code
+COPY --from=builder /opt/neurdb      /opt/neurdb
+COPY --from=builder /opt/neurdb-venv /opt/neurdb-venv
+
+# Create neurdb user, lock root account
+RUN useradd -m -s /bin/bash neurdb && passwd -l root
+
+# Set environment variables for the neurdb user
+ENV PATH="/opt/neurdb/bin:/opt/neurdb-venv/bin:${PATH}"
+ENV NEURDB_DATA="/var/lib/neurdb/data"
+
+EXPOSE 5432
+USER neurdb
+CMD ["/opt/neurdb/bin/docker-start.sh"]

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -39,6 +39,7 @@ RUN git clone --depth=1 -b PG16 \
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
 ENV PATH="/root/.cargo/bin:${PATH}"
 RUN cd /src/dbengine/nr_kernel && \
+    make clean && \
     make PG_CONFIG=/opt/neurdb/bin/pg_config && \
     make PG_CONFIG=/opt/neurdb/bin/pg_config install
 
@@ -76,6 +77,10 @@ ARG VARIANT
 FROM base-${VARIANT} AS release
 ENV DEBIAN_FRONTEND=noninteractive
 
+# Accept the host user's UID/GID so file ownership on bind-mounts matches
+ARG HOST_UID=1000
+ARG HOST_GID=1000
+
 # Runtime libraries only — no compilers, no -dev headers
 RUN apt-get update && apt-get install -y --no-install-recommends \
     librocksdb6.11 libwebsockets16 libcjson1 \
@@ -94,7 +99,9 @@ COPY --from=builder /opt/neurdb-venv /opt/neurdb-venv
 
 # Create neurdb user, lock root account, and pre-create the data directory
 # with correct ownership so the container starts correctly as a non-root user.
-RUN useradd -m -s /bin/bash neurdb && passwd -l root && \
+RUN groupadd -g ${HOST_GID} neurdb || true && \
+    useradd -m -s /bin/bash -u ${HOST_UID} -g ${HOST_GID} neurdb && \
+    passwd -l root && \
     mkdir -p /var/lib/neurdb/data /var/log/neurdb && \
     chown -R neurdb:neurdb /var/lib/neurdb /var/log/neurdb
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,225 @@
+# Installation
+
+## Quick Install (Docker)
+
+NeurDB can be installed with a single command using Docker.
+
+**Prerequisites:**
+
+| Requirement | Version |
+|---|---|
+| Docker Engine | 20.10+ |
+| OS | Linux (x86_64), Windows 10/11 with Docker Desktop |
+| GPU drivers (optional) | NVIDIA 470+ with CUDA 11.8 |
+
+**Linux:**
+```bash
+curl -fsSL https://github.com/neurdb/neurdb/releases/latest/download/install.sh | bash
+```
+
+**Windows (PowerShell as Administrator):**
+```powershell
+irm https://github.com/neurdb/neurdb/releases/latest/download/install.ps1 | iex
+```
+
+**Manual Docker install:**
+```bash
+# GPU (auto-detected if nvidia-smi is available)
+bash installer/linux/install.sh --gpu
+
+# CPU only
+bash installer/linux/install.sh --cpu
+
+# Custom port and persistent data
+bash installer/linux/install.sh --port 15432 --data-dir /data/neurdb
+```
+
+**Python client library:**
+```bash
+pip install neurdb
+```
+
+## Build from Source (Development)
+
+Our database is based on the PostgreSQL 16.3 with [doc](https://www.postgresql.org/docs/16/)
+
+### Clone the latest code
+
+```bash
+git clone https://github.com/neurdb/neurdb.git
+cd neurdb
+# Give Docker container write permission
+chmod -R 777 .
+```
+
+### Build with Docker
+
+```bash
+# Release build (builds both CPU and GPU variants, optimized, no debug tools)
+bash build.sh --release
+
+# Development build (with source mounting and debug port)
+bash build.sh --gpu
+bash build.sh --cpu
+```
+
+Wait until the following prompt shows:
+
+```
+Please use 'control + c' to exit the logging print
+...
+Press CTRL+C to quit
+```
+
+### Native Build on Linux
+
+> [!NOTE]
+> Tested on Ubuntu 22.04 (x86_64). Other Debian-based distributions should also work.
+
+**1. Install system dependencies:**
+
+```bash
+sudo apt-get update
+sudo apt-get install -y \
+    python3-dev python3-pip python-is-python3 \
+    build-essential gcc make cmake pkg-config \
+    clang flex bison \
+    libreadline-dev zlib1g-dev libicu-dev \
+    libssl-dev libclang-dev llvm-dev \
+    libcurl4-openssl-dev libwebsockets-dev libcjson-dev \
+    librocksdb-dev libpqxx-dev libopencv-dev \
+    curl git locales
+```
+
+Generate locale (needed by PostgreSQL):
+
+```bash
+sudo locale-gen en_US.UTF-8
+sudo update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8
+```
+
+**2. Set environment variables:**
+
+```bash
+export NEURDBPATH=$(pwd)                  # root of the neurdb repo
+export NR_BUILD_PATH=$NEURDBPATH/build
+export NR_PSQL_PATH=$NR_BUILD_PATH/psql
+export NR_DBDATA_PATH=$NR_BUILD_PATH/data
+export PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig
+export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:${LD_LIBRARY_PATH:-}
+export LIBCLANG_PATH=$(llvm-config --libdir)
+```
+
+**3. Build the DB engine (PostgreSQL):**
+
+```bash
+mkdir -p $NR_BUILD_PATH/dbengine $NR_PSQL_PATH
+cd $NR_BUILD_PATH/dbengine
+
+$NEURDBPATH/dbengine/configure --prefix=$NR_PSQL_PATH --enable-debug
+make -j$(nproc)
+make install
+```
+
+**4. Build pg_hint_plan extension:**
+
+```bash
+mkdir -p $NR_BUILD_PATH/contrib && cd $NR_BUILD_PATH/contrib
+git clone https://github.com/ossc-db/pg_hint_plan.git
+cd pg_hint_plan && git checkout PG16
+make PG_CONFIG=$NR_PSQL_PATH/bin/pg_config
+make PG_CONFIG=$NR_PSQL_PATH/bin/pg_config install
+```
+
+**5. Initialize and start the database:**
+
+```bash
+mkdir -p $NR_DBDATA_PATH
+$NR_PSQL_PATH/bin/initdb -D $NR_DBDATA_PATH
+$NR_PSQL_PATH/bin/pg_ctl -D $NR_DBDATA_PATH -l $NR_BUILD_PATH/logfile start
+
+# Wait for the server, then create the neurdb database
+$NR_PSQL_PATH/bin/createdb -h localhost -p 5432 neurdb
+```
+
+**6. Build NR kernel extensions:**
+
+```bash
+cd $NEURDBPATH/dbengine/nr_kernel
+export PG_CONFIG=$NR_PSQL_PATH/bin/pg_config
+make clean || true
+make
+make install
+```
+
+Register extensions and restart:
+
+```bash
+sed -i '/^#*shared_preload_libraries/d' $NR_DBDATA_PATH/postgresql.conf
+echo "shared_preload_libraries = 'pg_hint_plan, nr_molqo, nr_ext, nram, pg_neurstore'" >> $NR_DBDATA_PATH/postgresql.conf
+$NR_PSQL_PATH/bin/pg_ctl -D $NR_DBDATA_PATH -l $NR_BUILD_PATH/logfile restart
+```
+
+**7. Install AI engine dependencies and start the server:**
+
+```bash
+# CPU only
+pip install -r $NEURDBPATH/aiengine/runtime/requirements.cpu.txt \
+    --extra-index-url https://download.pytorch.org/whl/cpu
+
+# Or GPU (CUDA 11.x)
+pip install -r $NEURDBPATH/aiengine/runtime/requirements.txt \
+    --extra-index-url https://download.pytorch.org/whl/cu116
+
+# Start AI engine server
+cd $NEURDBPATH/aiengine/runtime
+NR_LOG_LEVEL=INFO python server.py &
+```
+
+**8. Install the NeurDB Python client API:**
+
+```bash
+cd $NEURDBPATH/api/python
+pip install -e .
+```
+
+**9. Create the pipeline extension:**
+
+```bash
+$NR_PSQL_PATH/bin/psql -h localhost -p 5432 -U $(whoami) -d neurdb \
+    -c 'CREATE EXTENSION IF NOT EXISTS nr_pipeline;'
+```
+
+### Native Build on Windows
+
+NeurDB does **not** build directly on Windows. Use **WSL2** (Windows Subsystem for Linux) to get a full Linux environment, then follow the Linux steps above.
+
+**1. Install WSL2** (PowerShell as Administrator):
+
+```powershell
+wsl --install -d Ubuntu-22.04
+```
+
+Restart your machine if prompted, then launch the **Ubuntu** terminal from the Start menu.
+
+**2. (Optional) Enable GPU pass-through:**
+
+If you have an NVIDIA GPU and want CUDA support inside WSL2, install the
+[NVIDIA CUDA on WSL driver](https://developer.nvidia.com/cuda/wsl) on the **Windows** side.
+Verify with:
+
+```bash
+nvidia-smi   # should show your GPU inside WSL2
+```
+
+**3. Follow the Linux build steps** listed above inside the WSL2 terminal.
+
+> [!TIP]
+> Your Windows filesystem is accessible under `/mnt/c/` inside WSL2, but for best build
+> performance, clone the repo into the Linux filesystem (e.g., `~/neurdb`).
+
+## Development
+
+[DB engine dev](./doc/db_dev.md)
+
+[AI engine dev](./doc/ai_dev.md)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -73,6 +73,10 @@ Press CTRL+C to quit
 
 ### Native Build on Linux
 
+> [!WARNING]
+> If you have previously compiled using Docker (`bash build.sh`), the source tree will contain leftover build artifacts with absolute symlinks pointing to Docker container paths. You **MUST** completely clean the repository before attempting a native build:
+> `git clean -xfd` (Warning: this deletes all untracked files)
+
 > [!NOTE]
 > Tested on Ubuntu 22.04 (x86_64). Other Debian-based distributions should also work.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -80,175 +80,36 @@ Press CTRL+C to quit
 > [!NOTE]
 > Tested on Ubuntu 22.04 (x86_64). Other Debian-based distributions should also work.
 
-**1. Install system dependencies:**
+You can natively compile and start the environment using the included `Makefile`:
 
 ```bash
-sudo apt-get update
-sudo apt-get install -y \
-    python3-dev python3-pip python-is-python3 \
-    build-essential gcc make cmake pkg-config \
-    clang flex bison \
-    libreadline-dev zlib1g-dev libicu-dev \
-    libssl-dev libclang-dev llvm-dev \
-    libcurl4-openssl-dev libwebsockets-dev libcjson-dev \
-    librocksdb-dev libpqxx-dev libopencv-dev \
-    curl git locales
-```
+# 1. Install prerequisites (Requires sudo)
+make deps
 
-Generate locale (needed by PostgreSQL):
-
-```bash
-sudo locale-gen en_US.UTF-8
-sudo update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8
-```
-
-**2. Set environment variables:**
-
-```bash
-# Change to the root of the neurdb repo
-cd neurdb
-
-# Set environment variables
-export NEURDBPATH="$(pwd)"
-export NR_BUILD_PATH="$NEURDBPATH/build"
-export NR_PSQL_PATH="$NR_BUILD_PATH/psql"
-export NR_DBDATA_PATH="$NR_BUILD_PATH/data"
-export MULTIARCH_LIBDIR="/usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)"
-export PKG_CONFIG_PATH="$MULTIARCH_LIBDIR/pkgconfig"
-export LD_LIBRARY_PATH="$MULTIARCH_LIBDIR:$LD_LIBRARY_PATH"
-export LIBCLANG_PATH="$(llvm-config --libdir)"
-export NR_DBENGINE_PATH="$NEURDBPATH/dbengine"
-export NR_KERNEL_PATH="$NR_DBENGINE_PATH/nr_kernel"
-export NR_AIENGINE_PATH="$NEURDBPATH/aiengine"
-export NR_API_PATH="$NEURDBPATH/api"
-```
-
-**3. Build the DB engine (PostgreSQL):**
-
-```bash
-mkdir -p $NR_BUILD_PATH/dbengine $NR_PSQL_PATH
-cd $NR_BUILD_PATH/dbengine
-
-# Configure and build (out-of-source build)
-$NR_DBENGINE_PATH/configure --prefix=$NR_PSQL_PATH --enable-debug
-make -j
-
-# If buidl errors, clean previous build artifacts and try again
-# rm -rf $NR_BUILD_PATH/dbengine/*
-
+# 2. Build and install the DB engine, extensions, API, and CPU AI engine
 make install
-```
 
-**4. Build pg_hint_plan extension:**
+# (Optional: Build the GPU AI engine instead)
+# make install AI_ENGINE_MODE=gpu
 
-```bash
-mkdir -p $NR_BUILD_PATH/contrib && cd $NR_BUILD_PATH/contrib
-if [ ! -d "pg_hint_plan" ]; then
-  git clone https://github.com/ossc-db/pg_hint_plan.git
-fi
-cd pg_hint_plan && git checkout PG16
-make PG_CONFIG=$NR_PSQL_PATH/bin/pg_config clean || true
-make PG_CONFIG=$NR_PSQL_PATH/bin/pg_config
-make PG_CONFIG=$NR_PSQL_PATH/bin/pg_config install
-```
-
-**5. Initialize and start the database:**
-
-```bash
-# Initialize data directory (skip if already exists)
-if [ ! -d "$NR_DBDATA_PATH" ]; then
-  mkdir -p $NR_DBDATA_PATH
-  $NR_PSQL_PATH/bin/initdb -D $NR_DBDATA_PATH
-else
-  chmod 0750 $NR_DBDATA_PATH
-fi
-
-# Start the database server
-$NR_PSQL_PATH/bin/pg_ctl -D $NR_DBDATA_PATH -l $NR_BUILD_PATH/logfile start
-
-# If the server fails to start with "could not start server", port 5432 already in use, then stop the postgresql instance or change the port
-# sudo systemctl stop postgresql
-
-# Wait for the server to be ready, then create the neurdb database
-until $NR_PSQL_PATH/bin/psql -h localhost -p 5432 -U $USER -c '\q' 2>/dev/null; do
-  echo 'NeurDB is unavailable - sleeping'
-  sleep 1
-  $NR_PSQL_PATH/bin/createdb -h localhost -p 5432 neurdb 2>/dev/null || true
-done
+# 3. Start the database background service and the AI server
+make start
 ```
 
 > [!TIP]
 > If the server fails to start with `could not start server`, check the log with
-> `cat $NR_BUILD_PATH/logfile`. Common causes:
-> - **Port 5432 already in use**: stop the other PostgreSQL instance (`sudo systemctl stop postgresql`) or change the port in `$NR_DBDATA_PATH/postgresql.conf`.
-> - **Permission denied on data directory**: run `chmod 0750 $NR_DBDATA_PATH`.
+> `cat build/logfile`. Common causes:
+> - **Port 5432 already in use**: stop the other PostgreSQL instance (`sudo systemctl stop postgresql`) or change the port in `build/data/postgresql.conf`.
+> - **Permission denied on data directory**: run `chmod 0750 build/data`.
 
-**6. Build NR kernel extensions:**
-
+When you are done, you can stop the services:
 ```bash
-cd $NR_KERNEL_PATH
-export PG_CONFIG=$NR_PSQL_PATH/bin/pg_config
-make clean || true
-make
-make install
+make stop
 ```
 
-Register extensions and restart:
-
-```bash
-sed -i '/^#*shared_preload_libraries/d' $NR_DBDATA_PATH/postgresql.conf
-echo "shared_preload_libraries = 'pg_hint_plan, nr_molqo, nr_ext, nram, pg_neurstore'" >> $NR_DBDATA_PATH/postgresql.conf
-$NR_PSQL_PATH/bin/pg_ctl -D $NR_DBDATA_PATH -l $NR_BUILD_PATH/logfile restart
-
-# Wait for the server to be ready after restart
-until $NR_PSQL_PATH/bin/psql -h localhost -p 5432 -U $USER -c '\q' 2>/dev/null; do
-  echo 'NeurDB is unavailable - sleeping'
-  sleep 1
-done
-```
-
-**7. Install AI engine dependencies and start the server:**
-
-```bash
-# CPU only
-pip install -r $NR_AIENGINE_PATH/runtime/requirements.cpu.txt \
-    --extra-index-url https://download.pytorch.org/whl/cpu
-
-# Or GPU (CUDA 11.x)
-pip install -r $NR_AIENGINE_PATH/runtime/requirements.txt \
-    --extra-index-url https://download.pytorch.org/whl/cu116
-
-# Start AI engine server
-cd $NR_AIENGINE_PATH/runtime
-export NR_LOG_LEVEL=INFO
-nohup python server.py &
-
-# Wait for the AI engine to be ready
-echo -n 'Waiting for AI engine to start '
-until curl --output /dev/null --silent --head --fail http://127.0.0.1:8090/; do
-  printf '.'
-  sleep 1
-done
-echo ' OK'
-```
-
-**8. Install the NeurDB Python client API:**
-
-```bash
-mkdir -p $NR_BUILD_PATH/api/python
-cp -r $NR_API_PATH/python/* $NR_BUILD_PATH/api/python/
-cd $NR_BUILD_PATH/api/python
-touch setup.cfg
-pip install -e .
-rm setup.cfg
-```
-
-**9. Create the pipeline extension:**
-
-```bash
-$NR_PSQL_PATH/bin/psql -h localhost -p 5432 -U $USER -d neurdb \
-    -c 'CREATE EXTENSION IF NOT EXISTS nr_pipeline;'
-```
+For advanced usage or troubleshooting, here are the other available commands:
+* `make clean`: Removes the build outputs to force a recompile but keeps the data directory.
+* `make distclean`: Deletes the entire `build/` directory including your data and configuration.
 
 ### Native Build on Windows
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -101,13 +101,22 @@ sudo update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8
 **2. Set environment variables:**
 
 ```bash
-export NEURDBPATH=$(pwd)                  # root of the neurdb repo
+# Change to the root of the neurdb repo
+cd neurdb
+
+# Set environment variables
+export NEURDBPATH=$(pwd)
 export NR_BUILD_PATH=$NEURDBPATH/build
 export NR_PSQL_PATH=$NR_BUILD_PATH/psql
 export NR_DBDATA_PATH=$NR_BUILD_PATH/data
-export PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig
-export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:${LD_LIBRARY_PATH:-}
+export MULTIARCH_LIBDIR=/usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)
+export PKG_CONFIG_PATH=$MULTIARCH_LIBDIR/pkgconfig
+export LD_LIBRARY_PATH=$MULTIARCH_LIBDIR:$LD_LIBRARY_PATH
 export LIBCLANG_PATH=$(llvm-config --libdir)
+export NR_DBENGINE_PATH=$NEURDBPATH/dbengine
+export NR_KERNEL_PATH=$NR_DBENGINE_PATH/nr_kernel
+export NR_AIENGINE_PATH=$NEURDBPATH/aiengine
+export NR_API_PATH=$NEURDBPATH/api
 ```
 
 **3. Build the DB engine (PostgreSQL):**
@@ -116,8 +125,9 @@ export LIBCLANG_PATH=$(llvm-config --libdir)
 mkdir -p $NR_BUILD_PATH/dbengine $NR_PSQL_PATH
 cd $NR_BUILD_PATH/dbengine
 
-$NEURDBPATH/dbengine/configure --prefix=$NR_PSQL_PATH --enable-debug
-make -j$(nproc)
+# Configure and build (out-of-source build)
+$NR_DBENGINE_PATH/configure --prefix=$NR_PSQL_PATH --enable-debug
+make -j
 make install
 ```
 
@@ -125,8 +135,11 @@ make install
 
 ```bash
 mkdir -p $NR_BUILD_PATH/contrib && cd $NR_BUILD_PATH/contrib
-git clone https://github.com/ossc-db/pg_hint_plan.git
+if [ ! -d "pg_hint_plan" ]; then
+  git clone https://github.com/ossc-db/pg_hint_plan.git
+fi
 cd pg_hint_plan && git checkout PG16
+make clean || true
 make PG_CONFIG=$NR_PSQL_PATH/bin/pg_config
 make PG_CONFIG=$NR_PSQL_PATH/bin/pg_config install
 ```
@@ -134,18 +147,35 @@ make PG_CONFIG=$NR_PSQL_PATH/bin/pg_config install
 **5. Initialize and start the database:**
 
 ```bash
-mkdir -p $NR_DBDATA_PATH
-$NR_PSQL_PATH/bin/initdb -D $NR_DBDATA_PATH
+# Initialize data directory (skip if already exists)
+if [ ! -d "$NR_DBDATA_PATH" ]; then
+  mkdir -p $NR_DBDATA_PATH
+  $NR_PSQL_PATH/bin/initdb -D $NR_DBDATA_PATH
+else
+  chmod 0750 $NR_DBDATA_PATH
+fi
+
+# Start the database server
 $NR_PSQL_PATH/bin/pg_ctl -D $NR_DBDATA_PATH -l $NR_BUILD_PATH/logfile start
 
-# Wait for the server, then create the neurdb database
-$NR_PSQL_PATH/bin/createdb -h localhost -p 5432 neurdb
+# Wait for the server to be ready, then create the neurdb database
+until $NR_PSQL_PATH/bin/psql -h localhost -p 5432 -U $USER -c '\q' 2>/dev/null; do
+  echo 'NeurDB is unavailable - sleeping'
+  sleep 1
+  $NR_PSQL_PATH/bin/createdb -h localhost -p 5432 neurdb 2>/dev/null || true
+done
 ```
+
+> [!TIP]
+> If the server fails to start with `could not start server`, check the log with
+> `cat $NR_BUILD_PATH/logfile`. Common causes:
+> - **Port 5432 already in use**: stop the other PostgreSQL instance (`sudo systemctl stop postgresql`) or change the port in `$NR_DBDATA_PATH/postgresql.conf`.
+> - **Permission denied on data directory**: run `chmod 0750 $NR_DBDATA_PATH`.
 
 **6. Build NR kernel extensions:**
 
 ```bash
-cd $NEURDBPATH/dbengine/nr_kernel
+cd $NR_KERNEL_PATH
 export PG_CONFIG=$NR_PSQL_PATH/bin/pg_config
 make clean || true
 make
@@ -158,35 +188,54 @@ Register extensions and restart:
 sed -i '/^#*shared_preload_libraries/d' $NR_DBDATA_PATH/postgresql.conf
 echo "shared_preload_libraries = 'pg_hint_plan, nr_molqo, nr_ext, nram, pg_neurstore'" >> $NR_DBDATA_PATH/postgresql.conf
 $NR_PSQL_PATH/bin/pg_ctl -D $NR_DBDATA_PATH -l $NR_BUILD_PATH/logfile restart
+
+# Wait for the server to be ready after restart
+until $NR_PSQL_PATH/bin/psql -h localhost -p 5432 -U $USER -c '\q' 2>/dev/null; do
+  echo 'NeurDB is unavailable - sleeping'
+  sleep 1
+done
 ```
 
 **7. Install AI engine dependencies and start the server:**
 
 ```bash
 # CPU only
-pip install -r $NEURDBPATH/aiengine/runtime/requirements.cpu.txt \
+pip install -r $NR_AIENGINE_PATH/runtime/requirements.cpu.txt \
     --extra-index-url https://download.pytorch.org/whl/cpu
 
 # Or GPU (CUDA 11.x)
-pip install -r $NEURDBPATH/aiengine/runtime/requirements.txt \
+pip install -r $NR_AIENGINE_PATH/runtime/requirements.txt \
     --extra-index-url https://download.pytorch.org/whl/cu116
 
 # Start AI engine server
-cd $NEURDBPATH/aiengine/runtime
-NR_LOG_LEVEL=INFO python server.py &
+cd $NR_AIENGINE_PATH/runtime
+export NR_LOG_LEVEL=INFO
+nohup python server.py &
+
+# Wait for the AI engine to be ready
+echo -n 'Waiting for AI engine to start '
+until curl --output /dev/null --silent --head --fail http://127.0.0.1:8090/; do
+  printf '.'
+  sleep 1
+done
+echo ' OK'
 ```
 
 **8. Install the NeurDB Python client API:**
 
 ```bash
-cd $NEURDBPATH/api/python
+mkdir -p $NR_BUILD_PATH/api/python
+cp -r $NR_API_PATH/python/* $NR_BUILD_PATH/api/python/
+cd $NR_BUILD_PATH/api/python
+touch setup.cfg
 pip install -e .
+rm setup.cfg
 ```
 
 **9. Create the pipeline extension:**
 
 ```bash
-$NR_PSQL_PATH/bin/psql -h localhost -p 5432 -U $(whoami) -d neurdb \
+$NR_PSQL_PATH/bin/psql -h localhost -p 5432 -U $USER -d neurdb \
     -c 'CREATE EXTENSION IF NOT EXISTS nr_pipeline;'
 ```
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -105,18 +105,18 @@ sudo update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8
 cd neurdb
 
 # Set environment variables
-export NEURDBPATH=$(pwd)
-export NR_BUILD_PATH=$NEURDBPATH/build
-export NR_PSQL_PATH=$NR_BUILD_PATH/psql
-export NR_DBDATA_PATH=$NR_BUILD_PATH/data
-export MULTIARCH_LIBDIR=/usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)
-export PKG_CONFIG_PATH=$MULTIARCH_LIBDIR/pkgconfig
-export LD_LIBRARY_PATH=$MULTIARCH_LIBDIR:$LD_LIBRARY_PATH
-export LIBCLANG_PATH=$(llvm-config --libdir)
-export NR_DBENGINE_PATH=$NEURDBPATH/dbengine
-export NR_KERNEL_PATH=$NR_DBENGINE_PATH/nr_kernel
-export NR_AIENGINE_PATH=$NEURDBPATH/aiengine
-export NR_API_PATH=$NEURDBPATH/api
+export NEURDBPATH="$(pwd)"
+export NR_BUILD_PATH="$NEURDBPATH/build"
+export NR_PSQL_PATH="$NR_BUILD_PATH/psql"
+export NR_DBDATA_PATH="$NR_BUILD_PATH/data"
+export MULTIARCH_LIBDIR="/usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)"
+export PKG_CONFIG_PATH="$MULTIARCH_LIBDIR/pkgconfig"
+export LD_LIBRARY_PATH="$MULTIARCH_LIBDIR:$LD_LIBRARY_PATH"
+export LIBCLANG_PATH="$(llvm-config --libdir)"
+export NR_DBENGINE_PATH="$NEURDBPATH/dbengine"
+export NR_KERNEL_PATH="$NR_DBENGINE_PATH/nr_kernel"
+export NR_AIENGINE_PATH="$NEURDBPATH/aiengine"
+export NR_API_PATH="$NEURDBPATH/api"
 ```
 
 **3. Build the DB engine (PostgreSQL):**
@@ -128,6 +128,10 @@ cd $NR_BUILD_PATH/dbengine
 # Configure and build (out-of-source build)
 $NR_DBENGINE_PATH/configure --prefix=$NR_PSQL_PATH --enable-debug
 make -j
+
+# If buidl errors, clean previous build artifacts and try again
+# rm -rf $NR_BUILD_PATH/dbengine/*
+
 make install
 ```
 
@@ -139,7 +143,7 @@ if [ ! -d "pg_hint_plan" ]; then
   git clone https://github.com/ossc-db/pg_hint_plan.git
 fi
 cd pg_hint_plan && git checkout PG16
-make clean || true
+make PG_CONFIG=$NR_PSQL_PATH/bin/pg_config clean || true
 make PG_CONFIG=$NR_PSQL_PATH/bin/pg_config
 make PG_CONFIG=$NR_PSQL_PATH/bin/pg_config install
 ```
@@ -157,6 +161,9 @@ fi
 
 # Start the database server
 $NR_PSQL_PATH/bin/pg_ctl -D $NR_DBDATA_PATH -l $NR_BUILD_PATH/logfile start
+
+# If the server fails to start with "could not start server", port 5432 already in use, then stop the postgresql instance or change the port
+# sudo systemctl stop postgresql
 
 # Wait for the server to be ready, then create the neurdb database
 until $NR_PSQL_PATH/bin/psql -h localhost -p 5432 -U $USER -c '\q' 2>/dev/null; do

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,142 @@
+.PHONY: help deps build install install-dbengine pg_hint_plan kernel_ext install-api install-aiengine initdb start-db start-ai start stop-db stop-ai stop clean distclean
+
+# Default variables as described in INSTALL.md
+NEURDBPATH ?= $(CURDIR)
+NR_BUILD_PATH ?= $(NEURDBPATH)/build
+NR_PSQL_PATH ?= $(NR_BUILD_PATH)/psql
+NR_DBDATA_PATH ?= $(NR_BUILD_PATH)/data
+
+# Multiarch libdir, defaults to x86_64-linux-gnu if dpkg-architecture is unavailable
+MULTIARCH_LIBDIR ?= /usr/lib/$(shell dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo x86_64-linux-gnu)
+export PKG_CONFIG_PATH := $(MULTIARCH_LIBDIR)/pkgconfig:$(PKG_CONFIG_PATH)
+export LD_LIBRARY_PATH := $(MULTIARCH_LIBDIR):$(LD_LIBRARY_PATH)
+
+# libclang path
+export LIBCLANG_PATH ?= $(shell llvm-config --libdir 2>/dev/null)
+
+NR_DBENGINE_PATH ?= $(NEURDBPATH)/dbengine
+NR_KERNEL_PATH ?= $(NR_DBENGINE_PATH)/nr_kernel
+NR_AIENGINE_PATH ?= $(NEURDBPATH)/aiengine
+NR_API_PATH ?= $(NEURDBPATH)/api
+
+AI_ENGINE_MODE ?= cpu
+
+help:
+	@echo "NeurDB Native Build Makefile"
+	@echo ""
+	@echo "Usage:"
+	@echo "  make deps          - Install system dependencies for Linux native build"
+	@echo "  make build         - Build the DB engine (PostgreSQL)"
+	@echo "  make install       - Install DB engine, extensions, API, and AI engine"
+	@echo "                       (Use AI_ENGINE_MODE=gpu for GPU support)"
+	@echo "  make start         - Initialize and start the database & AI engine"
+	@echo "  make stop          - Stop the database and AI engine"
+	@echo "  make clean         - Clean build artifacts (keeps data and psql binaries)"
+	@echo "  make distclean     - Remove the entire build directory (including data)"
+
+deps:
+	sudo apt-get update
+	sudo apt-get install -y \
+		python3-dev python3-pip python-is-python3 \
+		build-essential gcc make cmake pkg-config \
+		clang flex bison \
+		libreadline-dev zlib1g-dev libicu-dev \
+		libssl-dev libclang-dev llvm-dev \
+		libcurl4-openssl-dev libwebsockets-dev libcjson-dev \
+		librocksdb-dev libpqxx-dev libopencv-dev \
+		curl git locales
+	sudo locale-gen en_US.UTF-8
+	sudo update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8
+
+build:
+	mkdir -p $(NR_BUILD_PATH)/dbengine $(NR_PSQL_PATH)
+	cd $(NR_BUILD_PATH)/dbengine && \
+		$(NR_DBENGINE_PATH)/configure --prefix=$(NR_PSQL_PATH) --enable-debug && \
+		$(MAKE) -j
+
+install-dbengine: build
+	cd $(NR_BUILD_PATH)/dbengine && $(MAKE) install
+
+pg_hint_plan: install-dbengine
+	mkdir -p $(NR_BUILD_PATH)/contrib
+	cd $(NR_BUILD_PATH)/contrib && \
+		if [ ! -d "pg_hint_plan" ]; then \
+			git clone https://github.com/ossc-db/pg_hint_plan.git; \
+		fi && \
+		cd pg_hint_plan && git checkout PG16 && \
+		$(MAKE) PG_CONFIG=$(NR_PSQL_PATH)/bin/pg_config clean || true && \
+		$(MAKE) PG_CONFIG=$(NR_PSQL_PATH)/bin/pg_config && \
+		$(MAKE) PG_CONFIG=$(NR_PSQL_PATH)/bin/pg_config install
+
+kernel_ext: install-dbengine
+	cd $(NR_KERNEL_PATH) && \
+		PG_CONFIG=$(NR_PSQL_PATH)/bin/pg_config $(MAKE) clean || true && \
+		PG_CONFIG=$(NR_PSQL_PATH)/bin/pg_config $(MAKE) && \
+		PG_CONFIG=$(NR_PSQL_PATH)/bin/pg_config $(MAKE) install
+
+install-api:
+	mkdir -p $(NR_BUILD_PATH)/api/python
+	cp -r $(NR_API_PATH)/python/* $(NR_BUILD_PATH)/api/python/
+	cd $(NR_BUILD_PATH)/api/python && touch setup.cfg && pip install -e . && rm setup.cfg
+
+install-aiengine:
+ifeq ($(AI_ENGINE_MODE),cpu)
+	pip install -r $(NR_AIENGINE_PATH)/runtime/requirements.cpu.txt --extra-index-url https://download.pytorch.org/whl/cpu
+else
+	pip install -r $(NR_AIENGINE_PATH)/runtime/requirements.txt --extra-index-url https://download.pytorch.org/whl/cu116
+endif
+
+install: install-dbengine pg_hint_plan kernel_ext install-api install-aiengine
+
+initdb: install-dbengine
+	@if [ ! -d "$(NR_DBDATA_PATH)" ]; then \
+		mkdir -p $(NR_DBDATA_PATH); \
+		$(NR_PSQL_PATH)/bin/initdb -D $(NR_DBDATA_PATH); \
+	else \
+		chmod 0750 $(NR_DBDATA_PATH); \
+	fi
+
+start-db: initdb
+	$(NR_PSQL_PATH)/bin/pg_ctl -D $(NR_DBDATA_PATH) -l $(NR_BUILD_PATH)/logfile start || true
+	@echo "Waiting for PostgreSQL to start..."
+	@until $(NR_PSQL_PATH)/bin/psql -h localhost -p 5432 -U $(USER) -c '\q' 2>/dev/null; do \
+		echo 'NeurDB is unavailable - sleeping'; \
+		sleep 1; \
+	done
+	$(NR_PSQL_PATH)/bin/createdb -h localhost -p 5432 neurdb 2>/dev/null || true
+	@echo "Configuring shared_preload_libraries..."
+	sed -i '/^#*shared_preload_libraries/d' $(NR_DBDATA_PATH)/postgresql.conf
+	echo "shared_preload_libraries = 'pg_hint_plan, nr_molqo, nr_ext, nram, pg_neurstore'" >> $(NR_DBDATA_PATH)/postgresql.conf
+	$(NR_PSQL_PATH)/bin/pg_ctl -D $(NR_DBDATA_PATH) -l $(NR_BUILD_PATH)/logfile restart
+	@echo "Waiting for PostgreSQL to restart..."
+	@until $(NR_PSQL_PATH)/bin/psql -h localhost -p 5432 -U $(USER) -c '\q' 2>/dev/null; do \
+		echo 'NeurDB is unavailable - sleeping'; \
+		sleep 1; \
+	done
+	@echo "Creating nr_pipeline extension..."
+	$(NR_PSQL_PATH)/bin/psql -h localhost -p 5432 -U $(USER) -d neurdb -c 'CREATE EXTENSION IF NOT EXISTS nr_pipeline;'
+
+start-ai:
+	cd $(NR_AIENGINE_PATH)/runtime && NR_LOG_LEVEL=INFO nohup python server.py > $(NR_BUILD_PATH)/ai_engine.log 2>&1 &
+	@echo -n 'Waiting for AI engine to start '
+	@until curl --output /dev/null --silent --head --fail http://127.0.0.1:8090/; do \
+		printf '.'; \
+		sleep 1; \
+	done
+	@echo ' OK'
+
+start: start-db start-ai
+
+stop-db:
+	$(NR_PSQL_PATH)/bin/pg_ctl -D $(NR_DBDATA_PATH) stop || true
+
+stop-ai:
+	pkill -f "python server.py" || true
+
+stop: stop-db stop-ai
+
+clean:
+	rm -rf $(NR_BUILD_PATH)/dbengine $(NR_BUILD_PATH)/contrib $(NR_BUILD_PATH)/api
+
+distclean:
+	rm -rf $(NR_BUILD_PATH)

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,9 @@ help:
 	@echo "  make distclean     - Remove the entire build directory (including data)"
 
 deps:
+	@echo "========================================"
+	@echo "==> Running target: deps"
+	@echo "========================================"
 	sudo apt-get update
 	sudo apt-get install -y \
 		python3-dev python3-pip python-is-python3 \
@@ -49,15 +52,24 @@ deps:
 	sudo update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8
 
 build:
+	@echo "========================================"
+	@echo "==> Running target: build"
+	@echo "========================================"
 	mkdir -p $(NR_BUILD_PATH)/dbengine $(NR_PSQL_PATH)
 	cd $(NR_BUILD_PATH)/dbengine && \
 		$(NR_DBENGINE_PATH)/configure --prefix=$(NR_PSQL_PATH) --enable-debug && \
 		$(MAKE) -j
 
 install-dbengine: build
+	@echo "========================================"
+	@echo "==> Running target: install-dbengine"
+	@echo "========================================"
 	cd $(NR_BUILD_PATH)/dbengine && $(MAKE) install
 
 pg_hint_plan: install-dbengine
+	@echo "========================================"
+	@echo "==> Running target: pg_hint_plan"
+	@echo "========================================"
 	mkdir -p $(NR_BUILD_PATH)/contrib
 	cd $(NR_BUILD_PATH)/contrib && \
 		if [ ! -d "pg_hint_plan" ]; then \
@@ -69,17 +81,26 @@ pg_hint_plan: install-dbengine
 		$(MAKE) PG_CONFIG=$(NR_PSQL_PATH)/bin/pg_config install
 
 kernel_ext: install-dbengine
+	@echo "========================================"
+	@echo "==> Running target: kernel_ext"
+	@echo "========================================"
 	cd $(NR_KERNEL_PATH) && \
 		PG_CONFIG=$(NR_PSQL_PATH)/bin/pg_config $(MAKE) clean || true && \
 		PG_CONFIG=$(NR_PSQL_PATH)/bin/pg_config $(MAKE) && \
 		PG_CONFIG=$(NR_PSQL_PATH)/bin/pg_config $(MAKE) install
 
 install-api:
+	@echo "========================================"
+	@echo "==> Running target: install-api"
+	@echo "========================================"
 	mkdir -p $(NR_BUILD_PATH)/api/python
 	cp -r $(NR_API_PATH)/python/* $(NR_BUILD_PATH)/api/python/
 	cd $(NR_BUILD_PATH)/api/python && touch setup.cfg && pip install -e . && rm setup.cfg
 
 install-aiengine:
+	@echo "========================================"
+	@echo "==> Running target: install-aiengine"
+	@echo "========================================"
 ifeq ($(AI_ENGINE_MODE),cpu)
 	pip install -r $(NR_AIENGINE_PATH)/runtime/requirements.cpu.txt --extra-index-url https://download.pytorch.org/whl/cpu
 else
@@ -87,8 +108,14 @@ else
 endif
 
 install: install-dbengine pg_hint_plan kernel_ext install-api install-aiengine
+	@echo "========================================"
+	@echo "==> Finished target: install"
+	@echo "========================================"
 
 initdb: install-dbengine
+	@echo "========================================"
+	@echo "==> Running target: initdb"
+	@echo "========================================"
 	@if [ ! -d "$(NR_DBDATA_PATH)" ]; then \
 		mkdir -p $(NR_DBDATA_PATH); \
 		$(NR_PSQL_PATH)/bin/initdb -D $(NR_DBDATA_PATH); \
@@ -97,6 +124,9 @@ initdb: install-dbengine
 	fi
 
 start-db: initdb
+	@echo "========================================"
+	@echo "==> Running target: start-db"
+	@echo "========================================"
 	$(NR_PSQL_PATH)/bin/pg_ctl -D $(NR_DBDATA_PATH) -l $(NR_BUILD_PATH)/logfile start || true
 	@echo "Waiting for PostgreSQL to start..."
 	@until $(NR_PSQL_PATH)/bin/psql -h localhost -p 5432 -U $(USER) -c '\q' 2>/dev/null; do \
@@ -117,6 +147,9 @@ start-db: initdb
 	$(NR_PSQL_PATH)/bin/psql -h localhost -p 5432 -U $(USER) -d neurdb -c 'CREATE EXTENSION IF NOT EXISTS nr_pipeline;'
 
 start-ai:
+	@echo "========================================"
+	@echo "==> Running target: start-ai"
+	@echo "========================================"
 	cd $(NR_AIENGINE_PATH)/runtime && NR_LOG_LEVEL=INFO nohup python server.py > $(NR_BUILD_PATH)/ai_engine.log 2>&1 &
 	@echo -n 'Waiting for AI engine to start '
 	@until curl --output /dev/null --silent --head --fail http://127.0.0.1:8090/; do \
@@ -126,17 +159,35 @@ start-ai:
 	@echo ' OK'
 
 start: start-db start-ai
+	@echo "========================================"
+	@echo "==> Finished target: start"
+	@echo "========================================"
 
 stop-db:
+	@echo "========================================"
+	@echo "==> Running target: stop-db"
+	@echo "========================================"
 	$(NR_PSQL_PATH)/bin/pg_ctl -D $(NR_DBDATA_PATH) stop || true
 
 stop-ai:
+	@echo "========================================"
+	@echo "==> Running target: stop-ai"
+	@echo "========================================"
 	pkill -f "python server.py" || true
 
 stop: stop-db stop-ai
+	@echo "========================================"
+	@echo "==> Finished target: stop"
+	@echo "========================================"
 
 clean:
+	@echo "========================================"
+	@echo "==> Running target: clean"
+	@echo "========================================"
 	rm -rf $(NR_BUILD_PATH)/dbengine $(NR_BUILD_PATH)/contrib $(NR_BUILD_PATH)/api
 
 distclean:
+	@echo "========================================"
+	@echo "==> Running target: distclean"
+	@echo "========================================"
 	rm -rf $(NR_BUILD_PATH)

--- a/README.md
+++ b/README.md
@@ -27,17 +27,19 @@ NeurDB can be installed with a single command using Docker.
 | OS | Linux (x86_64), Windows 10/11 with Docker Desktop |
 | GPU drivers (optional) | NVIDIA 470+ with CUDA 11.8 |
 
-**Linux:**
+**Using pre-built Docker images:**
+
+*Linux:*
 ```bash
 curl -fsSL https://github.com/neurdb/neurdb/releases/latest/download/install.sh | bash
 ```
 
-**Windows (PowerShell as Administrator):**
+*Windows (PowerShell as Administrator):*
 ```powershell
 irm https://github.com/neurdb/neurdb/releases/latest/download/install.ps1 | iex
 ```
 
-**Manual Docker install:**
+**Manually Build from Docker:**
 ```bash
 # GPU (auto-detected if nvidia-smi is available)
 bash installer/linux/install.sh --gpu
@@ -54,43 +56,76 @@ bash installer/linux/install.sh --port 15432 --data-dir /data/neurdb
 pip install neurdb
 ```
 
-### Build from Source (Development)
+### Building from Source
 
-Our database is based on the PostgreSQL 16.3 with [doc](https://www.postgresql.org/docs/16/)
+For building from source (Docker or native on Linux/Windows), see **[INSTALL.md](./INSTALL.md)**.
 
-#### Clone the latest code
+## Usage
+
+### Connecting to NeurDB
+
+NeurDB is PostgreSQL-compatible, so you can connect using any PostgreSQL client. The default port is `5432`.
+
+**Using `psql`:**
+```bash
+psql -h localhost -p 5432 -U neurdb -d neurdb
+```
+
+### In-Database AI with SQL
+
+NeurDB extends SQL with a `PREDICT` statement for in-database AI inference:
+
+```sql
+-- Create a table and load data
+CREATE TABLE frappe_test (
+    click_rate INT, feature1 INT, feature2 INT,
+    feature3 INT, feature4 INT, feature5 INT,
+    feature6 INT, feature7 INT, feature8 INT,
+    feature9 INT, feature10 INT
+);
+
+COPY frappe_test FROM '/path/to/data.csv' DELIMITER ',' CSV HEADER;
+
+-- Configure training parameters
+SET nr_task_batch_size TO 60;
+SET nr_task_num_batches TO 100;
+
+-- Train and predict in a single statement
+PREDICT VALUE OF click_rate FROM frappe_test TRAIN ON *;
+```
+
+### Python Client
+
+Install the NeurDB Python client and use it to manage models programmatically:
 
 ```bash
-git clone https://github.com/neurdb/neurdb.git
-cd neurdb
-# Give Docker container write permission
-chmod -R 777 .
+pip install neurdb
 ```
 
-### Build Dockerfile
+```python
+from neurdb import NeurDB, ModelSerializer
+import torch
 
-```bash
-# Release build (builds both CPU and GPU variants, optimized, no debug tools)
-bash build.sh --release
+# Connect to a running NeurDB instance
+db = NeurDB(db_host="localhost", db_port="5432")
 
-# Development build (with source mounting and debug port)
-bash build.sh --gpu
-bash build.sh --cpu
+# Serialize and save a PyTorch model
+model = torch.nn.Linear(10, 2)
+pickled = ModelSerializer.serialize_model(model)
+model_id = db.save_model(pickled)
+
+# Load and restore the model
+loaded = db.load_model(model_id)
+restored_model = ModelSerializer.deserialize_model(loaded)
+
+# Register the model for in-database inference
+db.register_model(model_id, "my_table", ["feat1", "feat2"], ["target"])
+
+# Clean up
+db.close()
 ```
 
-Wait until the following prompt shows:
-
-```
-Please use 'control + c' to exit the logging print
-...
-Press CTRL+C to quit
-```
-
-### Development
-
-[DB engine dev](./doc/db_dev.md)
-
-[AI engine dev](./doc/ai_dev.md)
+For more details, see the [Python client documentation](./api/python/README.md).
 
 ## Citation
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,20 @@ pip install neurdb
 
 ### Building from Source
 
-For building from source (Docker or native on Linux/Windows), see **[INSTALL.md](./INSTALL.md#build-from-source-development)**.
+For native Linux builds, you can simply use the top-level `Makefile` to install prerequisites, build the engine, and start the services:
+
+```bash
+# 1. Install prerequisites (Requires sudo)
+make deps
+
+# 2. Build and install DB, AI engine, and Python client
+make install
+
+# 3. Start PostgreSQL and the AI Server
+make start
+```
+
+For detailed instructions spanning Docker builds, custom ports, GPU support, and Windows development, please see **[INSTALL.md](./INSTALL.md#build-from-source-development)**.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,50 @@ NeurDB is an AI-powered autonomous data system.
 
 ## Installation
 
+### Quick Install (Docker)
+
+NeurDB can be installed with a single command using Docker.
+
+**Prerequisites:**
+
+| Requirement | Version |
+|---|---|
+| Docker Engine | 20.10+ |
+| OS | Linux (x86_64), Windows 10/11 with Docker Desktop |
+| GPU drivers (optional) | NVIDIA 470+ with CUDA 11.8 |
+
+**Linux:**
+```bash
+curl -fsSL https://github.com/neurdb/neurdb/releases/latest/download/install.sh | bash
+```
+
+**Windows (PowerShell as Administrator):**
+```powershell
+irm https://github.com/neurdb/neurdb/releases/latest/download/install.ps1 | iex
+```
+
+**Manual Docker install:**
+```bash
+# GPU (auto-detected if nvidia-smi is available)
+bash installer/linux/install.sh --gpu
+
+# CPU only
+bash installer/linux/install.sh --cpu
+
+# Custom port and persistent data
+bash installer/linux/install.sh --port 15432 --data-dir /data/neurdb
+```
+
+**Python client library:**
+```bash
+pip install neurdb
+```
+
+### Build from Source (Development)
+
 Our database is based on the PostgreSQL 16.3 with [doc](https://www.postgresql.org/docs/16/)
 
-### Clone the latest code
+#### Clone the latest code
 
 ```bash
 git clone https://github.com/neurdb/neurdb.git
@@ -29,6 +70,11 @@ chmod -R 777 .
 ### Build Dockerfile
 
 ```bash
+# Release build (optimized, no debug tools)
+bash build.sh --release --cpu
+bash build.sh --release --gpu
+
+# Development build (with source mounting and debug port)
 bash build.sh --gpu
 bash build.sh --cpu
 ```

--- a/README.md
+++ b/README.md
@@ -70,9 +70,8 @@ chmod -R 777 .
 ### Build Dockerfile
 
 ```bash
-# Release build (optimized, no debug tools)
-bash build.sh --release --cpu
-bash build.sh --release --gpu
+# Release build (builds both CPU and GPU variants, optimized, no debug tools)
+bash build.sh --release
 
 # Development build (with source mounting and debug port)
 bash build.sh --gpu

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ pip install neurdb
 
 ### Building from Source
 
-For building from source (Docker or native on Linux/Windows), see **[INSTALL.md](./INSTALL.md)**.
+For building from source (Docker or native on Linux/Windows), see **[INSTALL.md](./INSTALL.md#build-from-source-development)**.
 
 ## Usage
 

--- a/aiengine/runtime/requirements.cpu.txt
+++ b/aiengine/runtime/requirements.cpu.txt
@@ -34,7 +34,7 @@ Pygments==2.15.1
 python-dateutil==2.9.0.post0
 python-engineio==4.9.1
 pytz==2024.1
-PyYAML==5.4.1
+PyYAML==6.0.2
 Quart==0.19.6
 requests==2.32.3
 scikit-learn==1.5.2

--- a/aiengine/runtime/requirements.txt
+++ b/aiengine/runtime/requirements.txt
@@ -49,7 +49,7 @@ python-dateutil==2.9.0.post0
 python-engineio==4.9.1
 python-socketio==5.11.3
 pytz==2024.1
-PyYAML==5.4.1
+PyYAML==6.0.2
 Quart==0.19.6
 requests==2.32.3
 scikit-learn==1.5.2

--- a/api/python/README.md
+++ b/api/python/README.md
@@ -1,24 +1,71 @@
-# NeurDB Python API
+# NeurDB Python Client
+
+Python client library for [NeurDB](https://neurdb.com) — an AI-powered autonomous data system.
 
 ## Installation
 
-### Editable (for Development)
+### Install from Local Distribution
 
-```sh
-pip install -e . --config-settings editable_mode=compat
-```
+To install the package from a local checkout (non-editable):
 
-### Normal (for Distribution)
-
-Changes to the source files are not directly reflected in the `neurdb` package. You should uninstall and reinstall the package to take effect.
-
-```sh
+```bash
 pip install .
 ```
 
-Reinstall using
+Note: changes to source files are not reflected until you reinstall:
 
-```sh
+```bash
 pip uninstall neurdb
 pip install .
 ```
+### Install from Python Package Index (PyPI)
+
+```bash
+pip install neurdb
+```
+
+## Quickstart
+
+```python
+from neurdb import NeurDB, ModelSerializer
+import torch
+
+# Connect to a running NeurDB instance
+db = NeurDB(db_host="localhost", db_port="5432")
+
+# Serialize and save a PyTorch model
+model = torch.nn.Linear(10, 2)
+pickled = ModelSerializer.serialize_model(model)
+model_id = db.save_model(pickled)
+
+# Load and restore the model
+loaded = db.load_model(model_id)
+restored_model = ModelSerializer.deserialize_model(loaded)
+
+# Register the model for in-database inference
+db.register_model(model_id, "my_table", ["feat1", "feat2"], ["target"])
+
+# Clean up
+db.close()
+```
+
+## Prerequisites
+
+A running NeurDB server is required. See the [main repository](https://github.com/neurdb/neurdb) for installation instructions.
+
+## Development
+
+```bash
+# Install in editable mode
+pip install -e ".[dev]"
+
+# Run tests
+pytest
+```
+
+
+## Links
+
+- [NeurDB Website](https://neurdb.com)
+- [GitHub Repository](https://github.com/neurdb/neurdb)
+- [Bug Tracker](https://github.com/neurdb/neurdb/issues)

--- a/api/python/pyproject.toml
+++ b/api/python/pyproject.toml
@@ -4,16 +4,48 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "neurdb"
+description = "Python client library for NeurDB — an AI-powered autonomous data system"
 dynamic = ["version"]
+readme = "README.md"
 requires-python = ">= 3.8"
 authors = [
   {name = "NeurDB Development Team", email = "dbsystem@comp.nus.edu.sg"},
 ]
 license = {file = "LICENSE"}
 keywords = ["NeurDB", "database", "AIxDB"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Database",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
+dependencies = [
+    "psycopg2-binary>=2.9",
+    "multipledispatch>=1.0",
+    "torch>=1.13",
+]
 
 [project.urls]
 Homepage = "https://neurdb.com"
+Repository = "https://github.com/neurdb/neurdb"
+Documentation = "https://neurdb.com"
+"Bug Tracker" = "https://github.com/neurdb/neurdb/issues"
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "pytest-cov",
+    "black",
+    "ruff",
+]
 
 [tool.setuptools.dynamic]
 version = {file = "VERSION"}

--- a/build.sh
+++ b/build.sh
@@ -100,11 +100,11 @@ else
 
     if [ "$MODE" == "cpu" ]; then
         docker run -d -e CLEAN_BUILD=1 --name neurdb_dev_opt \
-          -v "$(pwd)":/code/neurdb-dev \
-          -p ${DB_PORT}:5432 \
-          -p ${DEBUG_PORT}:1234 \
-          --cap-add=SYS_PTRACE \
-          neurdbimg-opt
+            -v "$(pwd)":/code/neurdb-dev \
+            -p ${DB_PORT}:5432 \
+            -p ${DEBUG_PORT}:1234 \
+            --cap-add=SYS_PTRACE \
+            neurdbimg
     else
         docker run -d -e CLEAN_BUILD=1 --name neurdb_dev \
             -v $(pwd):/code/neurdb-dev \

--- a/build.sh
+++ b/build.sh
@@ -84,39 +84,45 @@ if [ "$RELEASE" = true ]; then
     echo "  neurdb:latest-cpu"
     echo "  neurdb:latest-cuda11"
 else
-    # Dev build: existing behaviour, unchanged
-    docker rm -f neurdb_dev || true
-
+    # Container name based on mode
+    CONTAINER_NAME="neurdb_dev"
     if [ "$MODE" == "cpu" ]; then
-        docker build -t neurdbimg . -f Dockerfile.cpu --progress=plain --no-cache
-    else
-        docker build -t neurdbimg . -f Dockerfile.cuda11 --progress=plain --no-cache
+        CONTAINER_NAME="${CONTAINER_NAME}_cpu"
     fi
+
+    # Dev build: existing behaviour, unchanged
+    docker rm -f ${CONTAINER_NAME} || true
+
+    # Select Dockerfile based on mode
+    DOCKERFILE="Dockerfile.cuda11"
+    if [ "$MODE" == "cpu" ]; then
+        DOCKERFILE="Dockerfile.cpu"
+    fi
+
+    docker build -t neurdbimg . -f ${DOCKERFILE} --progress=plain --no-cache
 
     # Dev run: existing behaviour, unchanged
     # Clean build directory based on CLEAN_BUILD env var
     # CLEAN_BUILD=1        : clean everything (compile + data)
     # CLEAN_BUILD=compile  : clean compile only, keep data
 
-    if [ "$MODE" == "cpu" ]; then
-        docker run -d -e CLEAN_BUILD=1 --name neurdb_dev_opt \
-            -v "$(pwd)":/code/neurdb-dev \
-            -p ${DB_PORT}:5432 \
-            -p ${DEBUG_PORT}:1234 \
-            --cap-add=SYS_PTRACE \
-            neurdbimg
-    else
-        docker run -d -e CLEAN_BUILD=1 --name neurdb_dev \
-            -v $(pwd):/code/neurdb-dev \
-            -p ${DB_PORT}:5432 \
-            -p ${DEBUG_PORT}:1234 \
-            --cap-add=SYS_PTRACE \
-            --gpus all \
-            neurdbimg
+    # Set GPU_FLAG for docker run if in GPU mode
+    GPU_FLAG=""
+    if [ "$MODE" != "cpu" ]; then
+        GPU_FLAG="--gpus all"
     fi
 
+    # Run the Docker container with appropriate port mappings and GPU access
+    docker run -d -e CLEAN_BUILD=1 --name "${CONTAINER_NAME}" \
+        -v "$(pwd)":/code/neurdb-dev \
+        -p "${DB_PORT}:5432" \
+        -p "${DEBUG_PORT}:1234" \
+        --cap-add=SYS_PTRACE \
+        ${GPU_FLAG} \
+        neurdbimg
+
     # Follow the Docker container logs
-    docker logs -f neurdb_dev
+    docker logs -f ${CONTAINER_NAME}
 fi
 
 # psql -h localhost -U neurdb -d neurdb

--- a/build.sh
+++ b/build.sh
@@ -39,16 +39,34 @@ while [[ "$#" -gt 0 ]]; do
     shift
 done
 
+# Returns an available host port: uses the given default if free, otherwise
+# picks a random ephemeral port in 49152-65535.
+find_available_port() {
+    local preferred=$1
+    if ! ss -tlnH "sport = :${preferred}" 2>/dev/null | grep -q .; then
+        echo "$preferred"
+        return
+    fi
+    local port
+    while true; do
+        port=$(( RANDOM % 16383 + 49152 ))
+        if ! ss -tlnH "sport = :${port}" 2>/dev/null | grep -q .; then
+            echo "$port"
+            return
+        fi
+    done
+}
+
 # Set default ports based on mode if not specified
 if [ "$RELEASE" = true ]; then
-    DB_PORT=${DB_PORT:-5432}
+    DB_PORT=$(find_available_port "${DB_PORT:-5432}")
 else
     if [ "$MODE" == "cpu" ]; then
-        DB_PORT=${DB_PORT:-15432}
-        DEBUG_PORT=${DEBUG_PORT:-11234}
+        DB_PORT=$(find_available_port "${DB_PORT:-15432}")
+        DEBUG_PORT=$(find_available_port "${DEBUG_PORT:-11234}")
     else
-        DB_PORT=${DB_PORT:-5432}
-        DEBUG_PORT=${DEBUG_PORT:-1234}
+        DB_PORT=$(find_available_port "${DB_PORT:-5432}")
+        DEBUG_PORT=$(find_available_port "${DEBUG_PORT:-1234}")
     fi
 fi
 

--- a/build.sh
+++ b/build.sh
@@ -8,6 +8,7 @@ set -x
 
 # Set default mode to GPU
 MODE="gpu"
+RELEASE=false
 
 # Default port mappings (empty means use mode defaults)
 DB_PORT=""
@@ -18,6 +19,7 @@ while [[ "$#" -gt 0 ]]; do
     case $1 in
         --cpu) MODE="cpu" ;;
         --gpu) MODE="gpu" ;;
+        --release) RELEASE=true ;;
         --db-port) DB_PORT="$2"; shift ;;
         --debug-port) DEBUG_PORT="$2"; shift ;;
         -h|--help)
@@ -26,6 +28,7 @@ while [[ "$#" -gt 0 ]]; do
             echo "Options:"
             echo "  --cpu           Build and run in CPU mode"
             echo "  --gpu           Build and run in GPU mode (default)"
+            echo "  --release       Build and run the release image (Dockerfile.release)"
             echo "  --db-port PORT  Specify the host port for database (default: 5432 for GPU, 15432 for CPU)"
             echo "  --debug-port PORT  Specify the host port for debug server (default: 1234 for GPU, 11234 for CPU)"
             echo "  -h, --help      Show this help message"
@@ -37,53 +40,73 @@ while [[ "$#" -gt 0 ]]; do
 done
 
 # Set default ports based on mode if not specified
-if [ "$MODE" == "cpu" ]; then
-    DB_PORT=${DB_PORT:-15432}
-    DEBUG_PORT=${DEBUG_PORT:-11234}
-else
+if [ "$RELEASE" = true ]; then
     DB_PORT=${DB_PORT:-5432}
-    DEBUG_PORT=${DEBUG_PORT:-1234}
+else
+    if [ "$MODE" == "cpu" ]; then
+        DB_PORT=${DB_PORT:-15432}
+        DEBUG_PORT=${DEBUG_PORT:-11234}
+    else
+        DB_PORT=${DB_PORT:-5432}
+        DEBUG_PORT=${DEBUG_PORT:-1234}
+    fi
 fi
 
-# Remove the Docker container if it exists, suppressing errors if it doesn't
-docker rm -f neurdb_dev || true
+if [ "$RELEASE" = true ]; then
+    # Release build: uses Dockerfile.release, selects variant via build arg
+    VARIANT="cpu"
+    [ "$MODE" == "gpu" ] && VARIANT="cuda11"
+    IMAGE_NAME="neurdb:latest-${VARIANT}"
+    docker build \
+        -f Dockerfile.release \
+        --target release \
+        --build-arg VARIANT=${VARIANT} \
+        --progress=plain \
+        -t ${IMAGE_NAME} .
 
-# Build the Docker image based on the selected mode
-if [ "$MODE" == "cpu" ]; then
-    docker build -t neurdbimg . -f Dockerfile.cpu --progress=plain --no-cache
-else
-    docker build -t neurdbimg . -f Dockerfile.cuda11 --progress=plain --no-cache
-fi
-
-# This to solve the permission problems
-# chmod -R a+rwX .; \
-
-# Run the Docker container
-# You may replace or delete the port mapping
-
-# Clean build directory based on CLEAN_BUILD env var
-# CLEAN_BUILD=1        : clean everything (compile + data)
-# CLEAN_BUILD=compile  : clean compile only, keep data
-
-if [ "$MODE" == "cpu" ]; then
-    docker run -d -e CLEAN_BUILD=1 --name neurdb_dev_opt \
-      -v "$(pwd)":/code/neurdb-dev \
-      -p ${DB_PORT}:5432 \
-      -p ${DEBUG_PORT}:1234 \
-      --cap-add=SYS_PTRACE \
-      neurdbimg-opt
-else
-    docker run -d -e CLEAN_BUILD=1 --name neurdb_dev \
-        -v $(pwd):/code/neurdb-dev \
+    # Release run: no source mount, no debug port, no CLEAN_BUILD
+    CONTAINER_NAME="neurdb"
+    docker rm -f ${CONTAINER_NAME} || true
+    docker run -d \
+        --name ${CONTAINER_NAME} \
         -p ${DB_PORT}:5432 \
-        -p ${DEBUG_PORT}:1234 \
-        --cap-add=SYS_PTRACE \
-        --gpus all \
-        neurdbimg
+        --restart unless-stopped \
+        ${IMAGE_NAME}
+    docker logs -f ${CONTAINER_NAME}
+else
+    # Dev build: existing behaviour, unchanged
+    docker rm -f neurdb_dev || true
+
+    if [ "$MODE" == "cpu" ]; then
+        docker build -t neurdbimg . -f Dockerfile.cpu --progress=plain --no-cache
+    else
+        docker build -t neurdbimg . -f Dockerfile.cuda11 --progress=plain --no-cache
+    fi
+
+    # Dev run: existing behaviour, unchanged
+    # Clean build directory based on CLEAN_BUILD env var
+    # CLEAN_BUILD=1        : clean everything (compile + data)
+    # CLEAN_BUILD=compile  : clean compile only, keep data
+
+    if [ "$MODE" == "cpu" ]; then
+        docker run -d -e CLEAN_BUILD=1 --name neurdb_dev_opt \
+          -v "$(pwd)":/code/neurdb-dev \
+          -p ${DB_PORT}:5432 \
+          -p ${DEBUG_PORT}:1234 \
+          --cap-add=SYS_PTRACE \
+          neurdbimg-opt
+    else
+        docker run -d -e CLEAN_BUILD=1 --name neurdb_dev \
+            -v $(pwd):/code/neurdb-dev \
+            -p ${DB_PORT}:5432 \
+            -p ${DEBUG_PORT}:1234 \
+            --cap-add=SYS_PTRACE \
+            --gpus all \
+            neurdbimg
+    fi
+
+    # Follow the Docker container logs
+    docker logs -f neurdb_dev
 fi
-
-# Follow the Docker container logs
-docker logs -f neurdb_dev
-
 
 # psql -h localhost -U neurdb -d neurdb

--- a/build.sh
+++ b/build.sh
@@ -77,6 +77,8 @@ if [ "$RELEASE" = true ]; then
             -f Dockerfile.release \
             --target release \
             --build-arg VARIANT=${VARIANT} \
+            --build-arg HOST_UID=$(id -u) \
+            --build-arg HOST_GID=$(id -g) \
             --progress=plain \
             -t ${IMAGE_NAME} .
     done
@@ -99,7 +101,10 @@ else
         DOCKERFILE="Dockerfile.cpu"
     fi
 
-    docker build -t neurdbimg . -f ${DOCKERFILE} --progress=plain --no-cache
+    docker build -t neurdbimg . -f ${DOCKERFILE} \
+        --build-arg HOST_UID=$(id -u) \
+        --build-arg HOST_GID=$(id -g) \
+        --progress=plain --no-cache
 
     # Dev run: existing behaviour, unchanged
     # Clean build directory based on CLEAN_BUILD env var

--- a/build.sh
+++ b/build.sh
@@ -26,9 +26,9 @@ while [[ "$#" -gt 0 ]]; do
             echo "Usage: $0 [OPTIONS]"
             echo ""
             echo "Options:"
-            echo "  --cpu           Build and run in CPU mode"
-            echo "  --gpu           Build and run in GPU mode (default)"
-            echo "  --release       Build and run the release image (Dockerfile.release)"
+            echo "  --cpu           Build and run in CPU mode (dev)"
+            echo "  --gpu           Build and run in GPU mode (dev, default)"
+            echo "  --release       Build both CPU and GPU release images (Dockerfile.release)"
             echo "  --db-port PORT  Specify the host port for database (default: 5432 for GPU, 15432 for CPU)"
             echo "  --debug-port PORT  Specify the host port for debug server (default: 1234 for GPU, 11234 for CPU)"
             echo "  -h, --help      Show this help message"
@@ -57,10 +57,8 @@ find_available_port() {
     done
 }
 
-# Set default ports based on mode if not specified
-if [ "$RELEASE" = true ]; then
-    DB_PORT=$(find_available_port "${DB_PORT:-5432}")
-else
+# Set default ports based on mode if not specified (only needed for dev builds)
+if [ "$RELEASE" != true ]; then
     if [ "$MODE" == "cpu" ]; then
         DB_PORT=$(find_available_port "${DB_PORT:-15432}")
         DEBUG_PORT=$(find_available_port "${DEBUG_PORT:-11234}")
@@ -71,26 +69,20 @@ else
 fi
 
 if [ "$RELEASE" = true ]; then
-    # Release build: uses Dockerfile.release, selects variant via build arg
-    VARIANT="cpu"
-    [ "$MODE" == "gpu" ] && VARIANT="cuda11"
-    IMAGE_NAME="neurdb:latest-${VARIANT}"
-    docker build \
-        -f Dockerfile.release \
-        --target release \
-        --build-arg VARIANT=${VARIANT} \
-        --progress=plain \
-        -t ${IMAGE_NAME} .
-
-    # Release run: no source mount, no debug port, no CLEAN_BUILD
-    CONTAINER_NAME="neurdb"
-    docker rm -f ${CONTAINER_NAME} || true
-    docker run -d \
-        --name ${CONTAINER_NAME} \
-        -p ${DB_PORT}:5432 \
-        --restart unless-stopped \
-        ${IMAGE_NAME}
-    docker logs -f ${CONTAINER_NAME}
+    # Release build: build both CPU and GPU (cuda11) variants
+    for VARIANT in cpu cuda11; do
+        IMAGE_NAME="neurdb:latest-${VARIANT}"
+        echo "==> Building release image: ${IMAGE_NAME}"
+        docker build \
+            -f Dockerfile.release \
+            --target release \
+            --build-arg VARIANT=${VARIANT} \
+            --progress=plain \
+            -t ${IMAGE_NAME} .
+    done
+    echo "Release images built successfully:"
+    echo "  neurdb:latest-cpu"
+    echo "  neurdb:latest-cuda11"
 else
     # Dev build: existing behaviour, unchanged
     docker rm -f neurdb_dev || true

--- a/dbengine/nr_kernel/Makefile
+++ b/dbengine/nr_kernel/Makefile
@@ -1,13 +1,16 @@
 # List of subdirectories to process
 SUBDIRS := nr_ext nr_pipeline nr_am nr_store nr_molqo
 
+# PG_CONFIG can be overridden by the caller (e.g. make PG_CONFIG=/opt/neurdb/bin/pg_config)
+PG_CONFIG ?= pg_config
+
 # Build directory (for out-of-source build when source dir is read-only)
 NEURDBPATH ?= /code/neurdb-dev
 BUILD_DIR ?= $(NEURDBPATH)/build/nr_kernel
 SRC_DIR := $(CURDIR)
 
 # Default target: build all subprojects
-.PHONY: all $(SUBDIRS) install debug clean help sync distclean
+.PHONY: all $(SUBDIRS) install debug clean help sync distclean build-local install-local debug-local
 
 # Sync source to build directory
 sync:
@@ -15,9 +18,8 @@ sync:
 	@mkdir -p $(BUILD_DIR)
 	@rsync -a --delete --exclude='*.o' --exclude='*.so' --exclude='build/' $(SRC_DIR)/ $(BUILD_DIR)/
 
-# Default 'all' target: sync then build in build dir
-all: sync
-	@$(MAKE) -C $(BUILD_DIR) build-local
+# Default 'all' target: build directly in source dir (no sync required)
+all: build-local
 
 # Local build (called from build dir, no sync)
 build-local: $(SUBDIRS)
@@ -25,53 +27,49 @@ build-local: $(SUBDIRS)
 # Rule to handle each subdirectory
 $(SUBDIRS):
 	@echo "Building $@..."
-	$(MAKE) -C $@
+	$(MAKE) -C $@ PG_CONFIG=$(PG_CONFIG)
 
-# Install target: sync then install from build dir
-install: sync
-	@$(MAKE) -C $(BUILD_DIR) install-local
+# Install target: install directly from source dir (no sync required)
+install: install-local
 
 # Local install (called from build dir)
 install-local:
 	@for dir in $(SUBDIRS); do \
 		echo "Running 'make install' in $$dir"; \
-		$(MAKE) -C $$dir install; \
+		$(MAKE) -C $$dir install PG_CONFIG=$(PG_CONFIG) || exit 1; \
 	done
 
-# Debug target: sync then debug from build dir
-debug: sync
-	@$(MAKE) -C $(BUILD_DIR) debug-local
+# Debug target: build directly in source dir
+debug: debug-local
 
 # Local debug (called from build dir)
 debug-local:
 	@for dir in $(SUBDIRS); do \
 		echo "Running 'make debug' in $$dir"; \
-		$(MAKE) -C $$dir debug; \
+		$(MAKE) -C $$dir debug PG_CONFIG=$(PG_CONFIG); \
 	done
 
-# Clean target: clean build directory
+# Clean target: clean build directories in source dir
 clean:
-	@if [ -d "$(BUILD_DIR)" ]; then \
-		for dir in $(SUBDIRS); do \
-			echo "Cleaning in $$dir"; \
-			$(MAKE) -C $(BUILD_DIR)/$$dir clean || true; \
-		done \
-	fi
+	@for dir in $(SUBDIRS); do \
+		echo "Cleaning in $$dir"; \
+		$(MAKE) -C $(SRC_DIR)/$$dir clean || true; \
+	done
 
 distclean:
 	@echo "Cleaning CMake caches..."
-	@find $(BUILD_DIR) -name "CMakeCache.txt" -delete
-	@find $(BUILD_DIR) -name "cmake_install.cmake" -delete
-	@find $(BUILD_DIR) -type d -name "CMakeFiles" -exec rm -rf {} +
+	@find $(SRC_DIR) -name "CMakeCache.txt" -delete
+	@find $(SRC_DIR) -name "cmake_install.cmake" -delete
+	@find $(SRC_DIR) -type d -name "CMakeFiles" -exec rm -rf {} +
 
 # Help target to list available commands
 help:
 	@echo "Available targets:"
-	@echo "  all       - Sync and build all subprojects"
-	@echo "  install   - Sync and install all subprojects"
-	@echo "  debug     - Sync and debug all subprojects"
+	@echo "  all       - Build all subprojects"
+	@echo "  install   - Install all subprojects"
+	@echo "  debug     - Debug-build all subprojects"
 	@echo "  clean     - Clean all subprojects"
-	@echo "  sync      - Sync source to build directory"
-	@echo "  distclean - Clean build directory"
+	@echo "  sync      - Sync source to build directory (legacy dev workflow)"
+	@echo "  distclean - Clean CMake caches"
 	@echo ""
 	@echo "Build directory: $(BUILD_DIR)"

--- a/dbengine/nr_kernel/nr_am/CMakeLists.txt
+++ b/dbengine/nr_kernel/nr_am/CMakeLists.txt
@@ -7,15 +7,16 @@ set(CMAKE_SHARED_LIBRARY_PREFIX "")
 set(CMAKE_C_STANDARD 17)
 set(CMAKE_C_FLAGS "-Werror=implicit-function-declaration")
 
-# Set PostgreSQL paths
-set(PostgreSQL_ROOT /code/neurdb-dev/build/psql)
-set(PostgreSQL_LIBRARY_DIRS "${PostgreSQL_ROOT}/lib")
-set(PostgreSQL_INCLUDE_DIRS "${PostgreSQL_ROOT}/include")
-set(PostgreSQL_LIBDIR "${PostgreSQL_ROOT}/lib")
-set(PostgreSQL_SHAREDIR "${PostgreSQL_ROOT}/share")
+# Discover PostgreSQL paths via pg_config
+if(NOT DEFINED PG_CONFIG)
+    find_program(PG_CONFIG pg_config REQUIRED)
+endif()
+execute_process(COMMAND ${PG_CONFIG} --includedir-server OUTPUT_VARIABLE PostgreSQL_INCLUDE_DIRS OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process(COMMAND ${PG_CONFIG} --pkglibdir       OUTPUT_VARIABLE PostgreSQL_LIBDIR        OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process(COMMAND ${PG_CONFIG} --sharedir        OUTPUT_VARIABLE PostgreSQL_SHAREDIR      OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process(COMMAND ${PG_CONFIG} --libdir          OUTPUT_VARIABLE PostgreSQL_LIBRARY_DIRS  OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process(COMMAND ${PG_CONFIG} --libs            OUTPUT_VARIABLE PostgreSQL_LIBRARIES     OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-# Check PostgreSQL
-find_package(PostgreSQL REQUIRED)
 include_directories(
     ${PostgreSQL_INCLUDE_DIRS}
     ${CMAKE_CURRENT_SOURCE_DIR}/src
@@ -24,7 +25,6 @@ include_directories(
 # Add library
 FILE(GLOB_RECURSE SOURCES src/*.c src/*.cpp src/*.h src/*.hpp)
 add_library(nram SHARED ${SOURCES})
-target_link_libraries(nram ${PostgreSQL_LIBRARIES})
 
 # Install
 install(

--- a/dbengine/nr_kernel/nr_am/Makefile
+++ b/dbengine/nr_kernel/nr_am/Makefile
@@ -43,7 +43,7 @@ ROCKSDB_LIB_PATH = /usr/local/lib
 ROCKSDB_INC_PATH = /usr/local/include
 
 
-PG_CONFIG = $(NEURDBPATH)/build/psql/bin/pg_config
+PG_CONFIG ?= pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
 

--- a/dbengine/nr_kernel/nr_ext/CMakeLists.txt
+++ b/dbengine/nr_kernel/nr_ext/CMakeLists.txt
@@ -7,21 +7,21 @@ set(CMAKE_SHARED_LIBRARY_PREFIX "")
 set(CMAKE_C_STANDARD 17)
 set(CMAKE_C_FLAGS "-Werror=implicit-function-declaration")
 
-# Set PostgreSQL paths
-set(PostgreSQL_ROOT /code/neurdb-dev/build/psql)
-set(PostgreSQL_LIBRARY_DIRS "${PostgreSQL_ROOT}/lib")
-set(PostgreSQL_INCLUDE_DIRS "${PostgreSQL_ROOT}/include")
-set(PostgreSQL_LIBDIR "${PostgreSQL_ROOT}/lib")
-set(PostgreSQL_SHAREDIR "${PostgreSQL_ROOT}/share")
+# Discover PostgreSQL paths via pg_config
+if(NOT DEFINED PG_CONFIG)
+    find_program(PG_CONFIG pg_config REQUIRED)
+endif()
+execute_process(COMMAND ${PG_CONFIG} --includedir-server OUTPUT_VARIABLE PostgreSQL_INCLUDE_DIRS OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process(COMMAND ${PG_CONFIG} --pkglibdir       OUTPUT_VARIABLE PostgreSQL_LIBDIR        OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process(COMMAND ${PG_CONFIG} --sharedir        OUTPUT_VARIABLE PostgreSQL_SHAREDIR      OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process(COMMAND ${PG_CONFIG} --libdir          OUTPUT_VARIABLE PostgreSQL_LIBRARY_DIRS  OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process(COMMAND ${PG_CONFIG} --libs            OUTPUT_VARIABLE PostgreSQL_LIBRARIES     OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-# Check PostgreSQL
-find_package(PostgreSQL REQUIRED)
 include_directories(${PostgreSQL_INCLUDE_DIRS})
 
 # Add library
 FILE(GLOB_RECURSE SOURCES src/*.c src/*.cpp src/*.h src/*.hpp)
 add_library(nr_ext SHARED ${SOURCES})
-target_link_libraries(nr_ext ${PostgreSQL_LIBRARIES})
 
 # Install
 install(TARGETS nr_ext

--- a/dbengine/nr_kernel/nr_ext/Makefile
+++ b/dbengine/nr_kernel/nr_ext/Makefile
@@ -3,7 +3,9 @@
 
 EXT_NAME = nr_ext
 
-NEURDBPATH ?= /code/neurdb-dev
+PG_CONFIG ?= pg_config
+PG_SHAREDIR  := $(shell $(PG_CONFIG) --sharedir)
+PG_PKGLIBDIR := $(shell $(PG_CONFIG) --pkglibdir)
 
 .PHONY: all cmake buildext install clean
 
@@ -11,26 +13,21 @@ all: build buildext
 
 build:
 	mkdir -p build
-	cd build && cmake -DCMAKE_BUILD_TYPE=Release ..
+	cd build && cmake -DPG_CONFIG=$(PG_CONFIG) -DCMAKE_BUILD_TYPE=Release ..
 
 debug: builddbg buildextdbg
 
 builddbg:
 	mkdir -p build
-	cd build && cmake -DCMAKE_BUILD_TYPE=Debug ..
+	cd build && cmake -DPG_CONFIG=$(PG_CONFIG) -DCMAKE_BUILD_TYPE=Debug ..
 
 buildextdbg: buildext
-buildext:
-	cd build; make -j; cd ..
+buildext: build
+	$(MAKE) -j -C build
 
 install: buildext
-	cd build; make install; cd ..
-	cp $(EXT_NAME).control $(NEURDBPATH)/build/psql/share/postgresql/extension
-	# only works when in psql/lib/postgresql
-	rm -f $(NEURDBPATH)/build/psql/lib/$(EXT_NAME).so
-	rm -f $(NEURDBPATH)/build/psql/lib/postgresql/$(EXT_NAME).so
-	cp build/$(EXT_NAME).so $(NEURDBPATH)/build/psql/lib
-	cp build/$(EXT_NAME).so $(NEURDBPATH)/build/psql/lib/postgresql
+	$(MAKE) -C build install
+	cp $(EXT_NAME).control $(PG_SHAREDIR)/extension
 
 clean:
 	rm -rf build

--- a/dbengine/nr_kernel/nr_molqo/CMakeLists.txt
+++ b/dbengine/nr_kernel/nr_molqo/CMakeLists.txt
@@ -7,15 +7,16 @@ set(CMAKE_SHARED_LIBRARY_PREFIX "")
 set(CMAKE_C_STANDARD 17)
 set(CMAKE_C_FLAGS "-Werror=implicit-function-declaration")
 
-# Set PostgreSQL paths
-set(PostgreSQL_ROOT /code/neurdb-dev/build/psql)
-set(PostgreSQL_LIBRARY_DIRS "${PostgreSQL_ROOT}/lib")
-set(PostgreSQL_INCLUDE_DIRS "${PostgreSQL_ROOT}/include")
-set(PostgreSQL_LIBDIR "${PostgreSQL_ROOT}/lib")
-set(PostgreSQL_SHAREDIR "${PostgreSQL_ROOT}/share")
+# Discover PostgreSQL paths via pg_config
+if(NOT DEFINED PG_CONFIG)
+    find_program(PG_CONFIG pg_config REQUIRED)
+endif()
+execute_process(COMMAND ${PG_CONFIG} --includedir-server OUTPUT_VARIABLE PostgreSQL_INCLUDE_DIRS OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process(COMMAND ${PG_CONFIG} --pkglibdir       OUTPUT_VARIABLE PostgreSQL_LIBDIR        OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process(COMMAND ${PG_CONFIG} --sharedir        OUTPUT_VARIABLE PostgreSQL_SHAREDIR      OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process(COMMAND ${PG_CONFIG} --libdir          OUTPUT_VARIABLE PostgreSQL_LIBRARY_DIRS  OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process(COMMAND ${PG_CONFIG} --libs            OUTPUT_VARIABLE PostgreSQL_LIBRARIES     OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-# Check PostgreSQL
-find_package(PostgreSQL REQUIRED)
 include_directories(${PostgreSQL_INCLUDE_DIRS})
 
 # Base dir
@@ -28,7 +29,6 @@ set(SOURCES
     # src/http_client.c  # Uncomment when implementing real HTTP client
 )
 add_library(nr_molqo SHARED ${SOURCES})
-target_link_libraries(nr_molqo ${PostgreSQL_LIBRARIES})
 
 # Optional: Add HTTP client dependencies when ready
 # find_package(CURL REQUIRED)

--- a/dbengine/nr_kernel/nr_molqo/Makefile
+++ b/dbengine/nr_kernel/nr_molqo/Makefile
@@ -3,7 +3,9 @@
 
 EXT_NAME = nr_molqo
 
-NEURDBPATH ?= /code/neurdb-dev
+PG_CONFIG ?= pg_config
+PG_SHAREDIR  := $(shell $(PG_CONFIG) --sharedir)
+PG_PKGLIBDIR := $(shell $(PG_CONFIG) --pkglibdir)
 
 .PHONY: all cmake buildext install clean debug builddbg buildextdbg
 
@@ -11,27 +13,21 @@ all: build buildext
 
 build:
 	mkdir -p build
-	cd build && cmake -DCMAKE_BUILD_TYPE=Release ..
+	cd build && cmake -DPG_CONFIG=$(PG_CONFIG) -DCMAKE_BUILD_TYPE=Release ..
 
 debug: builddbg buildextdbg
 
 builddbg:
 	mkdir -p build
-	cd build && cmake -DCMAKE_BUILD_TYPE=Debug ..
+	cd build && cmake -DPG_CONFIG=$(PG_CONFIG) -DCMAKE_BUILD_TYPE=Debug ..
 
 buildextdbg: buildext
-buildext:
-	cd build; make -j; cd ..
+buildext: build
+	$(MAKE) -j -C build
 
 install: buildext
-	cd build; make install; cd ..
-	cp $(EXT_NAME).control $(NEURDBPATH)/build/psql/share/postgresql/extension
-	cp sql/nr_molqo--1.0.sql $(NEURDBPATH)/build/psql/share/postgresql/extension
-	# only works when in psql/lib/postgresql
-	rm -f $(NEURDBPATH)/build/psql/lib/$(EXT_NAME).so
-	rm -f $(NEURDBPATH)/build/psql/lib/postgresql/$(EXT_NAME).so
-	cp build/$(EXT_NAME).so $(NEURDBPATH)/build/psql/lib
-	cp build/$(EXT_NAME).so $(NEURDBPATH)/build/psql/lib/postgresql
+	$(MAKE) -C build install
+	cp $(EXT_NAME).control $(PG_SHAREDIR)/extension
 
 clean:
 	rm -rf build

--- a/dbengine/nr_kernel/nr_pipeline/CMakeLists.txt
+++ b/dbengine/nr_kernel/nr_pipeline/CMakeLists.txt
@@ -12,14 +12,16 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-set(PostgreSQL_ROOT /code/neurdb-dev/build/psql)
-set(PostgreSQL_LIBRARY_DIRS "${PostgreSQL_ROOT}/lib")
-set(PostgreSQL_INCLUDE_DIRS "${PostgreSQL_ROOT}/include")
-set(PostgreSQL_LIBDIR "${PostgreSQL_ROOT}/lib")
-set(PostgreSQL_SHAREDIR "${PostgreSQL_ROOT}/share")
+# Discover PostgreSQL paths via pg_config
+if(NOT DEFINED PG_CONFIG)
+    find_program(PG_CONFIG pg_config REQUIRED)
+endif()
+execute_process(COMMAND ${PG_CONFIG} --includedir-server OUTPUT_VARIABLE PostgreSQL_INCLUDE_DIRS OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process(COMMAND ${PG_CONFIG} --pkglibdir       OUTPUT_VARIABLE PostgreSQL_LIBDIR        OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process(COMMAND ${PG_CONFIG} --sharedir        OUTPUT_VARIABLE PostgreSQL_SHAREDIR      OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process(COMMAND ${PG_CONFIG} --libdir          OUTPUT_VARIABLE PostgreSQL_LIBRARY_DIRS  OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process(COMMAND ${PG_CONFIG} --libs            OUTPUT_VARIABLE PostgreSQL_LIBRARIES     OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-# PostgreSQL
-find_package(PostgreSQL REQUIRED)
 include_directories(${PostgreSQL_INCLUDE_DIRS})
 
 # CURL
@@ -39,7 +41,7 @@ FILE(GLOB_RECURSE SOURCES "src/*.c" "src/*.cpp")
 LIST(FILTER SOURCES EXCLUDE REGEX ".*src/interface.[ch]$") # use interface2.xxx as entry point
 LIST(FILTER SOURCES EXCLUDE REGEX ".*src/utils/network/http.c$")
 add_library(nr_pipeline SHARED ${SOURCES})
-target_link_libraries(nr_pipeline ${PostgreSQL_LIBRARIES} ${CURL_LIBRARIES} ${LWS_LIBRARY} ${SIO_CLIENT} OpenSSL::SSL OpenSSL::Crypto)
+target_link_libraries(nr_pipeline ${CURL_LIBRARIES} ${LWS_LIBRARY} ${SIO_CLIENT} OpenSSL::SSL OpenSSL::Crypto)
 
 # Install
 install(TARGETS nr_pipeline DESTINATION ${PostgreSQL_LIBDIR})

--- a/dbengine/nr_kernel/nr_pipeline/Makefile
+++ b/dbengine/nr_kernel/nr_pipeline/Makefile
@@ -3,7 +3,9 @@
 
 EXT_NAME = nr_pipeline
 
-NEURDBPATH ?= /code/neurdb-dev
+PG_CONFIG ?= pg_config
+PG_SHAREDIR  := $(shell $(PG_CONFIG) --sharedir)
+PG_PKGLIBDIR := $(shell $(PG_CONFIG) --pkglibdir)
 
 .PHONY: all cmake buildext install clean
 
@@ -11,7 +13,7 @@ all: cmake buildext
 
 build:
 	mkdir -p build
-	cd build && cmake -DCMAKE_BUILD_TYPE=Release ..
+	cd build && cmake -DPG_CONFIG=$(PG_CONFIG) -DCMAKE_BUILD_TYPE=Release ..
 
 debug: builddbg buildextdbg
 
@@ -21,17 +23,11 @@ builddbg:
 
 buildextdbg: buildext
 buildext: build
-	cd build; make -j; cd ..
+	$(MAKE) -j -C build
 
 install: buildext
-	cd build; make install; cd ..
-	cp $(EXT_NAME).control $(NEURDBPATH)/build/psql/share/postgresql/extension
-	cp sql/nr_pipeline--2.0.0.sql $(NEURDBPATH)/build/psql/share/postgresql/extension
-	# only works when in psql/lib/postgresql
-	rm -f $(NEURDBPATH)/build/psql/lib/$(EXT_NAME).so
-	rm -f $(NEURDBPATH)/build/psql/lib/postgresql/$(EXT_NAME).so
-	cp build/$(EXT_NAME).so $(NEURDBPATH)/build/psql/lib
-	cp build/$(EXT_NAME).so $(NEURDBPATH)/build/psql/lib/postgresql
+	$(MAKE) -C build install
+	cp $(EXT_NAME).control $(PG_SHAREDIR)/extension
 
 clean:
 	rm -rf build

--- a/dbengine/nr_kernel/nr_store/CMakeLists.txt
+++ b/dbengine/nr_kernel/nr_store/CMakeLists.txt
@@ -20,26 +20,38 @@ if (PG_ROOT)
 endif ()
 
 ############ Find packages ############
-set(PostgreSQL_ROOT /code/neurdb-dev/build/psql)
-set(PostgreSQL_LIBRARY_DIRS "${PostgreSQL_ROOT}/lib")
-set(PostgreSQL_INCLUDE_DIRS "${PostgreSQL_ROOT}/include")
-set(PostgreSQL_LIBDIR "${PostgreSQL_ROOT}/lib")
-set(PostgreSQL_SHAREDIR "${PostgreSQL_ROOT}/share")
+# Discover PostgreSQL paths via pg_config
+if(NOT DEFINED PG_CONFIG)
+    find_program(PG_CONFIG pg_config REQUIRED)
+endif()
+execute_process(COMMAND ${PG_CONFIG} --includedir-server OUTPUT_VARIABLE PostgreSQL_INCLUDE_DIRS OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process(COMMAND ${PG_CONFIG} --includedir        OUTPUT_VARIABLE PostgreSQL_CLIENT_INCLUDE_DIR OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process(COMMAND ${PG_CONFIG} --pkglibdir       OUTPUT_VARIABLE PostgreSQL_LIBDIR        OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process(COMMAND ${PG_CONFIG} --sharedir        OUTPUT_VARIABLE PostgreSQL_SHAREDIR      OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process(COMMAND ${PG_CONFIG} --libdir          OUTPUT_VARIABLE PostgreSQL_LIBRARY_DIRS  OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process(COMMAND ${PG_CONFIG} --libs            OUTPUT_VARIABLE PostgreSQL_LIBRARIES     OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+# pg_config --libs returns -lpgcommon and -lpgport which are non-PIC static
+# archives and cannot be linked into shared objects.  PostgreSQL ships PIC-safe
+# variants (_shlib) specifically for use by extensions and shared libraries.
+string(REPLACE "-lpgcommon" "-lpgcommon_shlib" PostgreSQL_LIBRARIES "${PostgreSQL_LIBRARIES}")
+string(REPLACE "-lpgport"   "-lpgport_shlib"   PostgreSQL_LIBRARIES "${PostgreSQL_LIBRARIES}")
 
 # postgresql
-find_package(PostgreSQL REQUIRED)
-if (NOT PostgreSQL_FOUND)
-    message(FATAL_ERROR "PostgreSQL not found")
+if (NOT PostgreSQL_INCLUDE_DIRS)
+    message(FATAL_ERROR "PostgreSQL server include directory not found (pg_config --includedir-server)")
 endif ()
 
-find_path(PostgreSQL_SERVER_INCLUDE_DIR
-        NAMES postgres.h
-        HINTS ${PostgreSQL_INCLUDE_DIRS}
-        PATH_SUFFIXES server 16/server
-)
-if (NOT PostgreSQL_SERVER_INCLUDE_DIR)
-    message(FATAL_ERROR "Could not find PostgreSQL server include directory (postgres.h)")
-endif ()
+# Add PostgreSQL library directory to linker search path so that internal
+# libraries (libpgcommon, libpgport) are found when PostgreSQL is installed
+# at a non-default prefix (e.g. /opt/neurdb/lib).
+link_directories(${PostgreSQL_LIBRARY_DIRS})
+
+# pg_config --includedir-server already points directly to the server include dir
+set(PostgreSQL_SERVER_INCLUDE_DIR ${PostgreSQL_INCLUDE_DIRS})
+
+# libpq-fe.h lives in the client include dir
+include_directories(${PostgreSQL_CLIENT_INCLUDE_DIR})
 
 # eigen
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/external/eigen)

--- a/dbengine/nr_kernel/nr_store/Makefile
+++ b/dbengine/nr_kernel/nr_store/Makefile
@@ -3,7 +3,9 @@
 EXT_NAME = pg_neurstore
 EXT_NAME_CORE = neurstore_core
 
-NEURDBPATH ?= /code/neurdb-dev
+PG_CONFIG ?= pg_config
+PG_SHAREDIR  := $(shell $(PG_CONFIG) --sharedir)
+PG_PKGLIBDIR := $(shell $(PG_CONFIG) --pkglibdir)
 
 BUILD_DIR ?= build
 CMAKE     ?= cmake
@@ -23,19 +25,19 @@ external: cargo
 
 configure: external
 	mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR) && $(CMAKE) ..
+	cd $(BUILD_DIR) && $(CMAKE) .. -DPG_CONFIG=$(PG_CONFIG)
 
 build: configure
 	$(CMAKE) --build $(BUILD_DIR)
 
 install: build
 	cd $(BUILD_DIR) && $(CMAKE) --build .
-	cp $(EXT_NAME).control $(NEURDBPATH)/build/psql/share/postgresql/extension
-	cp sql/pg_neurstore--1.0.0.sql $(NEURDBPATH)/build/psql/share/postgresql/extension
-	cp build/$(EXT_NAME).so $(NEURDBPATH)/build/psql/lib
-	cp build/$(EXT_NAME).so $(NEURDBPATH)/build/psql/lib/postgresql
-	cp build/$(EXT_NAME_CORE).so $(NEURDBPATH)/build/psql/lib
-	cp build/$(EXT_NAME_CORE).so $(NEURDBPATH)/build/psql/lib/postgresql
+	cp $(EXT_NAME).control $(PG_SHAREDIR)/extension
+	cp sql/pg_neurstore--1.0.0.sql $(PG_SHAREDIR)/extension
+	cp build/$(EXT_NAME).so $(PG_PKGLIBDIR)
+	cp build/$(EXT_NAME).so $(PG_PKGLIBDIR)/postgresql
+	cp build/$(EXT_NAME_CORE).so $(PG_PKGLIBDIR)
+	cp build/$(EXT_NAME_CORE).so $(PG_PKGLIBDIR)/postgresql
 
 clean:
 	rm -rf $(BUILD_DIR)

--- a/dbengine/src/include/catalog/nr_aiengine_d.h
+++ b/dbengine/src/include/catalog/nr_aiengine_d.h
@@ -1,1 +1,1 @@
-/code/neurdb-dev/dbengine/src/backend/catalog/nr_aiengine_d.h
+../../backend/catalog/nr_aiengine_d.h

--- a/docker-init.sh
+++ b/docker-init.sh
@@ -27,15 +27,15 @@ NR_KERNEL_PATH=$NR_DBENGINE_PATH/nr_kernel
 # CLEAN_BUILD=compile  : clean compile only, keep data
 if [ "$CLEAN_BUILD" = "1" ]; then
   echo "Cleaning entire build directory..."
-  rm -rf $NR_BUILD_PATH
+  sudo rm -rf $NR_BUILD_PATH
 elif [ "$CLEAN_BUILD" = "compile" ]; then
   echo "Cleaning compile artifacts, keeping data..."
-  rm -rf $NR_BUILD_PATH/dbengine
-  rm -rf $NR_BUILD_PATH/psql
-  rm -rf $NR_BUILD_PATH/nr_kernel
-  rm -rf $NR_BUILD_PATH/contrib
-  rm -rf $NR_BUILD_PATH/api
-  rm -f $NEURDBPATH/psql
+  sudo rm -rf $NR_BUILD_PATH/dbengine
+  sudo rm -rf $NR_BUILD_PATH/psql
+  sudo rm -rf $NR_BUILD_PATH/nr_kernel
+  sudo rm -rf $NR_BUILD_PATH/contrib
+  sudo rm -rf $NR_BUILD_PATH/api
+  sudo rm -f $NEURDBPATH/psql
 fi
 
 # # Install external lib.
@@ -52,7 +52,7 @@ mkdir -p $NR_PSQL_PATH
 
 # Create symlink for backward compatibility
 if [ "$NR_PSQL_PATH" != "$NEURDBPATH/psql" ]; then
-  rm -rf $NEURDBPATH/psql
+  sudo rm -rf $NEURDBPATH/psql
   ln -sf $NR_PSQL_PATH $NEURDBPATH/psql
 fi
 
@@ -73,7 +73,7 @@ if [ ! -d "pg_hint_plan" ]; then
 fi
 cd pg_hint_plan
 git checkout PG16
-make clean || true
+make PG_CONFIG=$NR_PSQL_PATH/bin/pg_config clean || true
 make PG_CONFIG=$NR_PSQL_PATH/bin/pg_config
 make PG_CONFIG=$NR_PSQL_PATH/bin/pg_config install
 echo 'pg_hint_plan installed!'

--- a/docker-start.sh
+++ b/docker-start.sh
@@ -11,8 +11,10 @@ PG_BIN="/opt/neurdb/bin"
 VENV_DIR="/opt/neurdb-venv"
 RUNTIME_DIR="${VENV_DIR}/runtime"
 
-# 1. Run initdb if data directory does not exist (first-run only)
-if [ ! -d "$NEURDB_DATA" ]; then
+# 1. Run initdb if the cluster has not been initialised yet (first-run only).
+# Check for PG_VERSION rather than the directory itself, because the directory
+# may have been pre-created (e.g. by the Dockerfile) without initdb having run.
+if [ ! -f "$NEURDB_DATA/PG_VERSION" ]; then
     mkdir -p "$NEURDB_DATA"
     "$PG_BIN/initdb" -D "$NEURDB_DATA" -U neurdb
 fi

--- a/docker-start.sh
+++ b/docker-start.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# Release entrypoint — startup only, no compilation.
+# All binaries are pre-built inside the Docker image.
+
+set -e
+
+NEURDB_DATA="${NEURDB_DATA:-/var/lib/neurdb/data}"
+NEURDB_LOG_DIR="/var/log/neurdb"
+PG_BIN="/opt/neurdb/bin"
+VENV_DIR="/opt/neurdb-venv"
+RUNTIME_DIR="${VENV_DIR}/runtime"
+
+# 1. Run initdb if data directory does not exist (first-run only)
+if [ ! -d "$NEURDB_DATA" ]; then
+    mkdir -p "$NEURDB_DATA"
+    "$PG_BIN/initdb" -D "$NEURDB_DATA" -U neurdb
+fi
+
+# 2. Patch postgresql.conf to load nr_kernel extensions
+sed -i '/^#*shared_preload_libraries/d' "$NEURDB_DATA/postgresql.conf"
+echo "shared_preload_libraries = 'pg_hint_plan, nr_molqo, nr_ext, nram, pg_neurstore'" >> "$NEURDB_DATA/postgresql.conf"
+
+# Allow connections from any host (for Docker port forwarding)
+if ! grep -q "listen_addresses = '\*'" "$NEURDB_DATA/postgresql.conf"; then
+    echo "listen_addresses = '*'" >> "$NEURDB_DATA/postgresql.conf"
+fi
+if ! grep -q "0.0.0.0/0" "$NEURDB_DATA/pg_hba.conf"; then
+    echo "host all all 0.0.0.0/0 trust" >> "$NEURDB_DATA/pg_hba.conf"
+fi
+
+# 3. Start PostgreSQL
+"$PG_BIN/pg_ctl" -D "$NEURDB_DATA" -l /tmp/neurdb-postgres.log start
+
+# 4. Wait for PostgreSQL to accept connections
+echo -n 'Waiting for NeurDB to start '
+until "$PG_BIN/psql" -h localhost -p 5432 -U neurdb -c '\q' 2>/dev/null; do
+    printf '.'
+    sleep 1
+    # 5. Create the 'neurdb' database if it does not exist
+    "$PG_BIN/createdb" -h localhost -p 5432 -U neurdb neurdb 2>/dev/null || true
+done
+echo ' OK'
+
+# 6. Install nr_pipeline extension
+"$PG_BIN/psql" -h localhost -p 5432 -U neurdb -c 'CREATE EXTENSION IF NOT EXISTS nr_pipeline;'
+echo 'NR Pipeline extension installed'
+
+# 7. Start the Python AI runtime server
+cd "$RUNTIME_DIR"
+export NR_LOG_LEVEL=INFO
+nohup "$VENV_DIR/bin/python" server.py > /tmp/neurdb-ai-server.log 2>&1 &
+
+# 8. Wait for the AI server to respond on :8090
+echo -n 'Waiting for AI runtime server to start '
+until curl --output /dev/null --silent --head --fail http://127.0.0.1:8090/; do
+    printf '.'
+    sleep 1
+done
+echo ' OK'
+
+echo "NeurDB is ready."
+echo "Connect with: psql -h localhost -p 5432 -U neurdb -d neurdb"
+
+# 9. Keep the container alive
+tail -f /dev/null

--- a/installer/linux/install-native.sh
+++ b/installer/linux/install-native.sh
@@ -1,0 +1,256 @@
+#!/bin/bash
+#
+# NeurDB Native Linux Installer
+# Called from install.sh --native
+#
+# This script installs NeurDB directly on the host without Docker.
+# Requires Ubuntu 20.04+, Debian 11+, or RHEL/Rocky 8+.
+#
+
+set -e
+
+# Defaults
+VERSION="latest"
+PORT=5432
+INSTALL_DIR="/opt/neurdb"
+DATA_DIR="/var/lib/neurdb/data"
+LOG_DIR="/var/log/neurdb"
+REGISTRY_URL="https://github.com/neurdb/neurdb/releases"
+
+usage() {
+    echo "NeurDB Native Linux Installer"
+    echo ""
+    echo "Usage: install-native.sh [OPTIONS]"
+    echo ""
+    echo "Options:"
+    echo "  --version VERSION   NeurDB version to install (default: latest)"
+    echo "  --port PORT         PostgreSQL port (default: 5432)"
+    echo "  -h, --help          Show this help message"
+    exit 0
+}
+
+# Parse arguments
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --version)  VERSION="$2"; shift ;;
+        --port)     PORT="$2"; shift ;;
+        -h|--help)  usage ;;
+        # Skip flags handled by the parent install.sh
+        --native|--cpu|--gpu) ;;
+        *) echo "Unknown parameter: $1"; exit 1 ;;
+    esac
+    shift
+done
+
+# Must run as root
+if [ "$(id -u)" -ne 0 ]; then
+    echo "Error: This script must be run as root (use sudo)."
+    exit 1
+fi
+
+# 1. Check the OS
+echo "Checking system requirements..."
+ARCH=$(uname -m)
+if [ "$ARCH" != "x86_64" ]; then
+    echo "Error: Only x86_64 architecture is supported. Detected: $ARCH"
+    exit 1
+fi
+
+if [ -f /etc/os-release ]; then
+    . /etc/os-release
+    case "$ID" in
+        ubuntu)
+            if [ "${VERSION_ID%%.*}" -lt 20 ]; then
+                echo "Error: Ubuntu 20.04 or later is required. Detected: $VERSION_ID"
+                exit 1
+            fi
+            PKG_MANAGER="apt"
+            ;;
+        debian)
+            if [ "${VERSION_ID%%.*}" -lt 11 ]; then
+                echo "Error: Debian 11 or later is required. Detected: $VERSION_ID"
+                exit 1
+            fi
+            PKG_MANAGER="apt"
+            ;;
+        rhel|rocky|centos|almalinux)
+            if [ "${VERSION_ID%%.*}" -lt 8 ]; then
+                echo "Error: RHEL/Rocky 8 or later is required. Detected: $VERSION_ID"
+                exit 1
+            fi
+            PKG_MANAGER="dnf"
+            ;;
+        *)
+            echo "Warning: Unsupported distribution '$ID'. Proceeding anyway..."
+            PKG_MANAGER="apt"
+            ;;
+    esac
+else
+    echo "Error: Cannot detect OS. /etc/os-release not found."
+    exit 1
+fi
+
+# 2. Create system user
+echo "Creating neurdb system user..."
+if ! id -u neurdb &>/dev/null; then
+    useradd --system --no-create-home --shell /usr/sbin/nologin neurdb
+fi
+
+# 3. Install system runtime dependencies
+echo "Installing runtime dependencies..."
+if [ "$PKG_MANAGER" = "apt" ]; then
+    apt-get update
+    apt-get install -y --no-install-recommends \
+        librocksdb6.11 libwebsockets16 libcjson1 \
+        libreadline8 libicu70 zlib1g libssl3 \
+        libopencv-core4.5d \
+        python3 python3-venv curl locales
+    locale-gen en_US.UTF-8 || true
+elif [ "$PKG_MANAGER" = "dnf" ]; then
+    dnf install -y \
+        rocksdb libwebsockets cjson \
+        readline icu zlib openssl-libs \
+        opencv-core \
+        python3 curl glibc-langpack-en
+fi
+
+# 4. Download and verify the tarball
+echo "Downloading NeurDB..."
+if [ "$VERSION" = "latest" ]; then
+    DOWNLOAD_URL="${REGISTRY_URL}/latest/download/neurdb-latest-linux-${ARCH}.tar.gz"
+    SUMS_URL="${REGISTRY_URL}/latest/download/SHA256SUMS"
+else
+    DOWNLOAD_URL="${REGISTRY_URL}/download/v${VERSION}/neurdb-${VERSION}-linux-${ARCH}.tar.gz"
+    SUMS_URL="${REGISTRY_URL}/download/v${VERSION}/SHA256SUMS"
+fi
+
+TMPDIR=$(mktemp -d)
+curl -fSL "$DOWNLOAD_URL" -o "$TMPDIR/neurdb.tar.gz"
+curl -fSL "$SUMS_URL" -o "$TMPDIR/SHA256SUMS"
+
+echo "Verifying download integrity..."
+cd "$TMPDIR"
+sha256sum -c SHA256SUMS
+cd /
+
+# 5. Extract to /opt/neurdb
+echo "Installing to ${INSTALL_DIR}..."
+rm -rf "$INSTALL_DIR"
+mkdir -p "$INSTALL_DIR"
+tar -xzf "$TMPDIR/neurdb.tar.gz" -C "$INSTALL_DIR" --strip-components=1
+rm -rf "$TMPDIR"
+
+# 6. Create data and log directories
+echo "Setting up directories..."
+mkdir -p "$DATA_DIR"
+mkdir -p "$LOG_DIR"
+chown -R neurdb:neurdb "$DATA_DIR"
+chown -R neurdb:neurdb "$LOG_DIR"
+
+# 7. Initialise the database cluster
+if [ ! -f "$DATA_DIR/PG_VERSION" ]; then
+    echo "Initializing database cluster..."
+    sudo -u neurdb "$INSTALL_DIR/bin/initdb" -D "$DATA_DIR" -U neurdb
+
+    # Patch postgresql.conf to load nr_kernel extensions
+    sed -i '/^#*shared_preload_libraries/d' "$DATA_DIR/postgresql.conf"
+    echo "shared_preload_libraries = 'pg_hint_plan, nr_molqo, nr_ext, nram, pg_neurstore'" >> "$DATA_DIR/postgresql.conf"
+
+    # Set the port
+    if [ "$PORT" != "5432" ]; then
+        sed -i "s/^#*port = .*/port = ${PORT}/" "$DATA_DIR/postgresql.conf"
+    fi
+
+    # Allow local connections
+    echo "listen_addresses = 'localhost'" >> "$DATA_DIR/postgresql.conf"
+fi
+
+# 8. Install systemd service units
+echo "Installing systemd services..."
+if [ -f "$INSTALL_DIR/installer/neurdb-db.service" ]; then
+    cp "$INSTALL_DIR/installer/neurdb-db.service" /etc/systemd/system/
+    cp "$INSTALL_DIR/installer/neurdb-ai.service" /etc/systemd/system/
+else
+    # Use co-located service files
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    cp "$SCRIPT_DIR/neurdb-db.service" /etc/systemd/system/
+    cp "$SCRIPT_DIR/neurdb-ai.service" /etc/systemd/system/
+fi
+systemctl daemon-reload
+
+# 9. Enable and start services
+echo "Starting NeurDB services..."
+systemctl enable neurdb-db neurdb-ai
+systemctl start neurdb-db
+
+# Wait for DB to be ready
+echo -n "Waiting for database to start "
+MAX_WAIT=60
+ELAPSED=0
+until sudo -u neurdb "$INSTALL_DIR/bin/psql" -h localhost -p "$PORT" -U neurdb -c '\q' 2>/dev/null; do
+    printf '.'
+    sleep 1
+    ELAPSED=$((ELAPSED + 1))
+    if [ "$ELAPSED" -ge "$MAX_WAIT" ]; then
+        echo ""
+        echo "Warning: Database did not become ready within ${MAX_WAIT}s."
+        echo "Check logs: journalctl -u neurdb-db"
+        exit 1
+    fi
+    # Create neurdb database if needed
+    sudo -u neurdb "$INSTALL_DIR/bin/createdb" -h localhost -p "$PORT" -U neurdb neurdb 2>/dev/null || true
+done
+echo " OK"
+
+# Install nr_pipeline extension
+sudo -u neurdb "$INSTALL_DIR/bin/psql" -h localhost -p "$PORT" -U neurdb -c 'CREATE EXTENSION IF NOT EXISTS nr_pipeline;'
+
+# Start AI runtime
+systemctl start neurdb-ai
+
+# Wait for AI server
+echo -n "Waiting for AI runtime server to start "
+ELAPSED=0
+until curl --output /dev/null --silent --head --fail http://127.0.0.1:8090/; do
+    printf '.'
+    sleep 1
+    ELAPSED=$((ELAPSED + 1))
+    if [ "$ELAPSED" -ge "$MAX_WAIT" ]; then
+        echo ""
+        echo "Warning: AI server did not start within ${MAX_WAIT}s."
+        echo "Check logs: journalctl -u neurdb-ai"
+        break
+    fi
+done
+echo " OK"
+
+# 10. Install PATH integration
+echo 'export PATH="/opt/neurdb/bin:$PATH"' > /etc/profile.d/neurdb.sh
+chmod 644 /etc/profile.d/neurdb.sh
+
+# Install convenience wrapper
+cat > /usr/local/bin/neurdb-psql << 'WRAPPER'
+#!/bin/bash
+exec /opt/neurdb/bin/psql -h localhost -U neurdb -d neurdb "$@"
+WRAPPER
+chmod +x /usr/local/bin/neurdb-psql
+
+# 11. Print connection info
+echo ""
+echo "============================================"
+echo "  NeurDB has been installed!"
+echo "============================================"
+echo ""
+echo "  Connect with:"
+echo "    neurdb-psql"
+echo "    # or"
+echo "    psql -h localhost -p ${PORT} -U neurdb -d neurdb"
+echo ""
+echo "  Service management:"
+echo "    systemctl status neurdb-db neurdb-ai"
+echo "    systemctl restart neurdb-db"
+echo "    journalctl -u neurdb-db -f"
+echo ""
+echo "  Uninstall:"
+echo "    /opt/neurdb/installer/uninstall.sh"
+echo ""

--- a/installer/linux/install.sh
+++ b/installer/linux/install.sh
@@ -1,0 +1,175 @@
+#!/bin/bash
+#
+# NeurDB Installer for Linux (Docker mode)
+# Usage: install.sh [OPTIONS]
+#
+# Options:
+#   --version VERSION   NeurDB version to install (default: latest)
+#   --cpu               Force CPU image
+#   --gpu               Force GPU image (default: auto-detect)
+#   --port PORT         Host port for PostgreSQL (default: 5432)
+#   --data-dir PATH     Bind mount for persistent data
+#   --uninstall         Stop and remove the NeurDB container and image
+#   --native            Install natively (no Docker) — see Phase 3
+#
+
+set -e
+
+# Defaults
+VERSION="latest"
+VARIANT=""
+PORT=5432
+DATA_DIR=""
+UNINSTALL=false
+NATIVE=false
+CONTAINER_NAME="neurdb"
+REGISTRY="ghcr.io/neurdb/neurdb"
+
+usage() {
+    echo "NeurDB Installer for Linux"
+    echo ""
+    echo "Usage: $0 [OPTIONS]"
+    echo ""
+    echo "Options:"
+    echo "  --version VERSION   NeurDB version to install (default: latest)"
+    echo "  --cpu               Force CPU image"
+    echo "  --gpu               Force GPU image (default: auto-detect)"
+    echo "  --port PORT         Host port for PostgreSQL (default: 5432)"
+    echo "  --data-dir PATH     Bind mount for persistent data outside the container"
+    echo "  --uninstall         Stop and remove the NeurDB container and image"
+    echo "  --native            Install natively without Docker (requires Ubuntu 20.04+)"
+    echo "  -h, --help          Show this help message"
+    exit 0
+}
+
+# Parse arguments
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --version)  VERSION="$2"; shift ;;
+        --cpu)      VARIANT="cpu" ;;
+        --gpu)      VARIANT="cuda11" ;;
+        --port)     PORT="$2"; shift ;;
+        --data-dir) DATA_DIR="$2"; shift ;;
+        --uninstall) UNINSTALL=true ;;
+        --native)   NATIVE=true ;;
+        -h|--help)  usage ;;
+        *) echo "Unknown parameter: $1"; exit 1 ;;
+    esac
+    shift
+done
+
+# --- Uninstall mode ---
+if [ "$UNINSTALL" = true ]; then
+    echo "Stopping and removing NeurDB..."
+    docker stop "$CONTAINER_NAME" 2>/dev/null || true
+    docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
+    # Remove images
+    for tag in $(docker images --format '{{.Repository}}:{{.Tag}}' | grep "neurdb"); do
+        docker rmi "$tag" 2>/dev/null || true
+    done
+    echo "NeurDB has been uninstalled."
+    exit 0
+fi
+
+# --- Native mode placeholder (implemented in Phase 3, Step 3.3) ---
+if [ "$NATIVE" = true ]; then
+    # Source the native installation logic
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    if [ -f "$SCRIPT_DIR/install-native.sh" ]; then
+        exec bash "$SCRIPT_DIR/install-native.sh" "$@"
+    else
+        echo "Error: Native installation is not yet available."
+        echo "Please use Docker mode (remove --native flag)."
+        exit 1
+    fi
+fi
+
+# --- Docker mode ---
+
+# 1. Check prerequisites
+if ! command -v docker &>/dev/null; then
+    echo "Error: Docker is not installed."
+    echo "Install Docker: https://docs.docker.com/engine/install/"
+    exit 1
+fi
+
+if ! docker info &>/dev/null; then
+    echo "Error: Docker daemon is not running."
+    echo "Start Docker with: sudo systemctl start docker"
+    exit 1
+fi
+
+# 2. Detect GPU availability if not explicitly set
+if [ -z "$VARIANT" ]; then
+    if command -v nvidia-smi &>/dev/null && nvidia-smi &>/dev/null; then
+        echo "NVIDIA GPU detected — using GPU image."
+        VARIANT="cuda11"
+    else
+        echo "No NVIDIA GPU detected — using CPU image."
+        VARIANT="cpu"
+    fi
+fi
+
+# 3. Determine image tag
+if [ "$VERSION" = "latest" ]; then
+    IMAGE_TAG="latest-${VARIANT}"
+else
+    IMAGE_TAG="${VERSION}-${VARIANT}"
+fi
+IMAGE="${REGISTRY}:${IMAGE_TAG}"
+
+echo "Pulling NeurDB image: ${IMAGE}"
+docker pull "$IMAGE"
+
+# 4. Stop existing container if running
+docker stop "$CONTAINER_NAME" 2>/dev/null || true
+docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
+
+# 5. Build run command
+RUN_ARGS=(-d --name "$CONTAINER_NAME" -p "${PORT}:5432" --restart unless-stopped)
+
+if [ -n "$DATA_DIR" ]; then
+    mkdir -p "$DATA_DIR"
+    RUN_ARGS+=(-v "${DATA_DIR}:/var/lib/neurdb/data")
+fi
+
+if [ "$VARIANT" = "cuda11" ]; then
+    RUN_ARGS+=(--gpus all)
+fi
+
+RUN_ARGS+=("$IMAGE")
+
+echo "Starting NeurDB container..."
+docker run "${RUN_ARGS[@]}"
+
+# 6. Wait for readiness
+echo -n "Waiting for NeurDB to be ready "
+MAX_WAIT=120
+ELAPSED=0
+while ! docker exec "$CONTAINER_NAME" /opt/neurdb/bin/psql -h localhost -p 5432 -U neurdb -c '\q' 2>/dev/null; do
+    printf '.'
+    sleep 2
+    ELAPSED=$((ELAPSED + 2))
+    if [ "$ELAPSED" -ge "$MAX_WAIT" ]; then
+        echo ""
+        echo "Warning: NeurDB did not become ready within ${MAX_WAIT}s."
+        echo "Check logs with: docker logs $CONTAINER_NAME"
+        exit 1
+    fi
+done
+echo " OK"
+
+# 7. Print connection info
+echo ""
+echo "============================================"
+echo "  NeurDB is running!"
+echo "============================================"
+echo ""
+echo "  Connect with:"
+echo "    psql -h localhost -p ${PORT} -U neurdb -d neurdb"
+echo ""
+echo "  Container name: ${CONTAINER_NAME}"
+echo "  View logs:      docker logs -f ${CONTAINER_NAME}"
+echo "  Stop:           docker stop ${CONTAINER_NAME}"
+echo "  Uninstall:      $0 --uninstall"
+echo ""

--- a/installer/linux/neurdb-ai.service
+++ b/installer/linux/neurdb-ai.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=NeurDB AI Runtime Server
+After=neurdb-db.service
+Requires=neurdb-db.service
+
+[Service]
+Type=simple
+User=neurdb
+WorkingDirectory=/opt/neurdb/aiengine/runtime
+ExecStart=/opt/neurdb/aiengine/venv/bin/python server.py
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/installer/linux/neurdb-db.service
+++ b/installer/linux/neurdb-db.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=NeurDB Database Server
+After=network.target
+
+[Service]
+Type=forking
+User=neurdb
+ExecStart=/opt/neurdb/bin/pg_ctl -D /var/lib/neurdb/data -l /var/log/neurdb/postgres.log start
+ExecStop=/opt/neurdb/bin/pg_ctl -D /var/lib/neurdb/data stop
+ExecReload=/opt/neurdb/bin/pg_ctl -D /var/lib/neurdb/data reload
+
+[Install]
+WantedBy=multi-user.target

--- a/installer/linux/uninstall.sh
+++ b/installer/linux/uninstall.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+#
+# NeurDB Uninstaller for Native Linux Installation
+#
+
+set -e
+
+# Must run as root
+if [ "$(id -u)" -ne 0 ]; then
+    echo "Error: This script must be run as root (use sudo)."
+    exit 1
+fi
+
+echo "NeurDB Uninstaller"
+echo "=================="
+
+# 1. Stop and disable systemd services
+echo "Stopping NeurDB services..."
+systemctl stop neurdb-ai 2>/dev/null || true
+systemctl stop neurdb-db 2>/dev/null || true
+systemctl disable neurdb-ai 2>/dev/null || true
+systemctl disable neurdb-db 2>/dev/null || true
+
+# 2. Remove service unit files
+echo "Removing systemd units..."
+rm -f /etc/systemd/system/neurdb-db.service
+rm -f /etc/systemd/system/neurdb-ai.service
+
+# 3. Reload systemd
+systemctl daemon-reload
+
+# 4. Remove binary installation
+echo "Removing /opt/neurdb/..."
+rm -rf /opt/neurdb
+
+# 5. Remove PATH integration
+rm -f /etc/profile.d/neurdb.sh
+rm -f /usr/local/bin/neurdb-psql
+
+# 6. Optionally remove data
+if [ -d "/var/lib/neurdb" ]; then
+    echo ""
+    echo "WARNING: /var/lib/neurdb contains your database data."
+    read -rp "Delete database data? This CANNOT be undone. [y/N] " CONFIRM
+    if [[ "$CONFIRM" =~ ^[Yy]$ ]]; then
+        rm -rf /var/lib/neurdb
+        echo "Database data removed."
+    else
+        echo "Database data preserved at /var/lib/neurdb"
+    fi
+fi
+
+# Remove log directory
+rm -rf /var/log/neurdb
+
+# 7. Remove the neurdb system user
+if id -u neurdb &>/dev/null; then
+    echo "Removing neurdb system user..."
+    userdel neurdb 2>/dev/null || true
+fi
+
+echo ""
+echo "NeurDB has been uninstalled."

--- a/installer/windows/install.ps1
+++ b/installer/windows/install.ps1
@@ -1,0 +1,165 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    NeurDB Installer for Windows (Docker mode)
+
+.DESCRIPTION
+    Pulls and runs the NeurDB Docker image on Windows via Docker Desktop/WSL2.
+    GPU is not supported on Windows — CPU image only.
+
+.PARAMETER Version
+    NeurDB version to install (default: latest)
+
+.PARAMETER Port
+    Host port for PostgreSQL (default: 5432)
+
+.PARAMETER DataDir
+    Optional bind mount for persistent data outside the container
+
+.PARAMETER Uninstall
+    Stop and remove the NeurDB container and image
+#>
+
+param(
+    [string]$Version = "latest",
+    [int]$Port = 5432,
+    [string]$DataDir = "",
+    [switch]$Uninstall,
+    [switch]$Help
+)
+
+$ContainerName = "neurdb"
+$Registry = "ghcr.io/neurdb/neurdb"
+$Variant = "cpu"  # Windows: CPU only
+
+function Show-Usage {
+    Write-Host "NeurDB Installer for Windows"
+    Write-Host ""
+    Write-Host "Usage: .\install.ps1 [OPTIONS]"
+    Write-Host ""
+    Write-Host "Options:"
+    Write-Host "  -Version VERSION   NeurDB version to install (default: latest)"
+    Write-Host "  -Port PORT         Host port for PostgreSQL (default: 5432)"
+    Write-Host "  -DataDir PATH      Bind mount for persistent data"
+    Write-Host "  -Uninstall         Stop and remove the NeurDB container and image"
+    Write-Host "  -Help              Show this help message"
+    exit 0
+}
+
+if ($Help) { Show-Usage }
+
+# --- Uninstall mode ---
+if ($Uninstall) {
+    Write-Host "Stopping and removing NeurDB..."
+    docker stop $ContainerName 2>$null
+    docker rm -f $ContainerName 2>$null
+    docker images --format "{{.Repository}}:{{.Tag}}" | Select-String "neurdb" | ForEach-Object {
+        docker rmi $_.ToString() 2>$null
+    }
+    Write-Host "NeurDB has been uninstalled."
+    exit 0
+}
+
+# --- Check prerequisites ---
+
+# Check Docker Desktop
+$dockerPath = Get-Command docker -ErrorAction SilentlyContinue
+if (-not $dockerPath) {
+    Write-Host "Error: Docker is not installed." -ForegroundColor Red
+    Write-Host "Download Docker Desktop: https://www.docker.com/products/docker-desktop/"
+    exit 1
+}
+
+# Check Docker daemon
+try {
+    docker info 2>$null | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw }
+} catch {
+    Write-Host "Error: Docker daemon is not running." -ForegroundColor Red
+    Write-Host "Please start Docker Desktop and try again."
+    exit 1
+}
+
+# Check WSL2 backend
+$wslCheck = docker info 2>$null | Select-String "OSType: linux"
+if (-not $wslCheck) {
+    Write-Host "Warning: Docker does not appear to be using Linux containers." -ForegroundColor Yellow
+    Write-Host "Ensure Docker Desktop is configured to use WSL2 backend with Linux containers."
+}
+
+# --- Determine image tag ---
+if ($Version -eq "latest") {
+    $ImageTag = "latest-$Variant"
+} else {
+    $ImageTag = "$Version-$Variant"
+}
+$Image = "${Registry}:${ImageTag}"
+
+Write-Host "Pulling NeurDB image: $Image"
+docker pull $Image
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "Error: Failed to pull image." -ForegroundColor Red
+    exit 1
+}
+
+# --- Stop existing container ---
+docker stop $ContainerName 2>$null
+docker rm -f $ContainerName 2>$null
+
+# --- Build run command ---
+$runArgs = @(
+    "run", "-d",
+    "--name", $ContainerName,
+    "-p", "${Port}:5432",
+    "--restart", "unless-stopped"
+)
+
+if ($DataDir -ne "") {
+    if (-not (Test-Path $DataDir)) {
+        New-Item -ItemType Directory -Path $DataDir -Force | Out-Null
+    }
+    $runArgs += @("-v", "${DataDir}:/var/lib/neurdb/data")
+}
+
+$runArgs += $Image
+
+Write-Host "Starting NeurDB container..."
+& docker @runArgs
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "Error: Failed to start container." -ForegroundColor Red
+    exit 1
+}
+
+# --- Wait for readiness ---
+Write-Host -NoNewline "Waiting for NeurDB to be ready "
+$maxWait = 120
+$elapsed = 0
+while ($true) {
+    $result = docker exec $ContainerName /opt/neurdb/bin/psql -h localhost -p 5432 -U neurdb -c '\q' 2>$null
+    if ($LASTEXITCODE -eq 0) { break }
+    Write-Host -NoNewline "."
+    Start-Sleep -Seconds 2
+    $elapsed += 2
+    if ($elapsed -ge $maxWait) {
+        Write-Host ""
+        Write-Host "Warning: NeurDB did not become ready within ${maxWait}s." -ForegroundColor Yellow
+        Write-Host "Check logs with: docker logs $ContainerName"
+        exit 1
+    }
+}
+Write-Host " OK"
+
+# --- Print connection info ---
+Write-Host ""
+Write-Host "============================================"
+Write-Host "  NeurDB is running!"
+Write-Host "============================================"
+Write-Host ""
+Write-Host "  Connect with:"
+Write-Host "    psql -h localhost -p $Port -U neurdb -d neurdb"
+Write-Host ""
+Write-Host "  Container name: $ContainerName"
+Write-Host "  View logs:      docker logs -f $ContainerName"
+Write-Host "  Stop:           docker stop $ContainerName"
+Write-Host "  Uninstall:      .\install.ps1 -Uninstall"
+Write-Host ""


### PR DESCRIPTION
# Summary

This PR introduces a complete build and distribution infrastructure for NeurDB, including Docker images for CPU and GPU targets, installation scripts for Linux and Windows, CI/CD automation, and several follow-up fixes to stabilize the build pipeline.

# Changes

## Installation & Distribution
- Add Linux installation scripts (`install.sh`, `install-native.sh`, `uninstall.sh`) and a Windows PowerShell installer (`install.ps1`)
- Add a top-level `Makefile` to simplify native Linux source builds
- Add systemd service unit files for neurdb-db and neurdb-ai
- Add `Dockerfile.release` for building production-ready images
- Add docker-start.sh for container entrypoint management

## CI/CD Workflows
- Add `docker-publish.yml` to build and publish Docker images to a registry
- Add `pypi-publish.yml` to publish the Python package to PyPI
- Add `build-native.yml` for native (non-Docker) build testing
- Update `docker-build-dev.yml`

## Python Package
- Add `pyproject.toml` for the neurdb Python package
- Expand `api/python/README.md` with usage documentation
- Build script (`build.sh`) improvements

## Support building both CPU and GPU images in release mode
- Fix CPU mode in dev builds
- Simplify and unify CPU/GPU build logic in dev mode

## Bug Fixes
- Fix LD_LIBRARY_PATH handling in `Dockerfile.cpu` and `Dockerfile.cuda11` to correctly append to the existing path rather than overwrite it
- Fix multiple bugs in release mode Docker builds across `Dockerfile.release`, `build.sh`, and dbengine `Makefiles`/`CMakeLists`
- Fix dependency versions in `requirements.txt` and `requirements.cpu.txt`

# Test Plan

## Completed Tests
- [x] Build CPU dev image: `./build.sh --cpu`
- [x] Build GPU dev image: `./build.sh --gpu`
- [x] Build CPU & GPU release images: `./build.sh --release`
- [x] Verify LD_LIBRARY_PATH is correctly set inside the container
- [x] Native Linux installation via `make`
- [x] Installation on Windows via WSL.

## Pending Tests
- [ ] Verify CI workflows trigger on push and complete successfully

